### PR TITLE
Feat/uniswap candles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ graphcache-go
 tmp*
 .DS_Store
 
+.env
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "go",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "main.go"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -20,23 +20,28 @@ By default the instance uses the network config at `./config/networks.json`. To 
 
 The RPC endpoint can be overriden in the environment by setting the `RPC_MAINNET` env variable before running:
 
-    export RPC_MAINNET=[RPC_URL] 
+    export RPC_MAINNET=[RPC_URL]
     ./graphcache-go
 
 ## Endpoints
 
 The following exposed endpoints and their URL and paramters are listed in `server/server.go`
 
-* `gcgo/user_balance_tokens` - List all tokens the user has potential surplus collateral
-* `gcgo/user_positions` - List all concentrated and ambient liquidity positions
-* `gcgo/pool_positions` - List N most recent concentrated and ambient positions in a pool
-* `gcgo/pool_position_apy_leaders` - List top N positions in pool by annualized fee APY
-* `gcgo/user_pool_positions` - List liquidity positions of a user in a single pool
-* `gcgo/position_stats` - Describe a single liquidity position
-* `gcgo/user_limit_orders` - List all non-zero knockout liquidity positions of a user
-* `gcgo/pool_limit_orders` - List N most recent knockout liquidity position in a pool
-* `gcgo/user_pool_limit_orders` - List knockout positions of a user in a single pool
-* `gcgo/limit_stats` - Describe a single knockout position
-* `gcgo/user_txs` - List all dex trading transactions of a user
-* `gcgo/pool_txs` - List N most recent trading transactions in a pool
-* `gcgo/pool_liq_curve` - Return the most recent description of the liquidity curve in a pool
+- `gcgo/user_balance_tokens` - List all tokens the user has potential surplus collateral
+- `gcgo/user_positions` - List all concentrated and ambient liquidity positions
+- `gcgo/pool_positions` - List N most recent concentrated and ambient positions in a pool
+- `gcgo/pool_position_apy_leaders` - List top N positions in pool by annualized fee APY
+- `gcgo/user_pool_positions` - List liquidity positions of a user in a single pool
+- `gcgo/position_stats` - Describe a single liquidity position
+- `gcgo/user_limit_orders` - List all non-zero knockout liquidity positions of a user
+- `gcgo/pool_limit_orders` - List N most recent knockout liquidity position in a pool
+- `gcgo/user_pool_limit_orders` - List knockout positions of a user in a single pool
+- `gcgo/limit_stats` - Describe a single knockout position
+- `gcgo/user_txs` - List all dex trading transactions of a user
+- `gcgo/pool_txs` - List N most recent trading transactions in a pool
+- `gcgo/pool_liq_curve` - Return the most recent description of the liquidity curve in a pool
+
+## Uniswap Candles
+
+Create a .env file and add the var: `UNISWAP_CANDLES=true`
+This will run the repo in such a way that only the swaps from uniswap syncs and no other data is pulled. This is meant to be run alongside the normal implementation of graphcache-go to supplement candles from other pools and historical data. Candles will be found at the same endpoint when run in this mode.

--- a/artifacts/graphQueries/swaps.uniswap.query
+++ b/artifacts/graphQueries/swaps.uniswap.query
@@ -1,5 +1,6 @@
 query($minTime: BigInt, $maxTime: BigInt, $orderDir: OrderDirection) {
-swaps(first: 1000, where: { timestamp_gte: $minTime, timestamp_lte: $maxTime }
+swaps(first: 1000, orderBy: timestamp, orderDirection: $orderDir,  
+      where: { timestamp_gte: $minTime, timestamp_lte: $maxTime }
 ) {
   id
   transaction {

--- a/artifacts/graphQueries/swaps.uniswap.query
+++ b/artifacts/graphQueries/swaps.uniswap.query
@@ -1,0 +1,26 @@
+query($minTime: BigInt, $maxTime: BigInt, $orderDir: OrderDirection) {
+swaps(first: 1000, where: { timestamp_gte: $minTime, timestamp_lte: $maxTime }
+) {
+  id
+  transaction {
+    id
+    blockNumber
+  }
+  pool {
+    id
+    token0 {
+      id
+      symbol
+    }
+    token1 {
+      id
+      symbol
+    }
+  }
+  sender
+  recipient
+  amount0
+  amount1
+  timestamp
+ }
+}

--- a/cache/transactors.go
+++ b/cache/transactors.go
@@ -30,7 +30,7 @@ func (m *MemoryCache) RetrievePoolSet() []types.PoolLocation {
 	return m.poolTradingHistory.keySet()
 }
 
-func (m *MemoryCache) RetrivePoolTxs(pool types.PoolLocation) []types.PoolTxEvent {
+func (m *MemoryCache) RetrievePoolTxs(pool types.PoolLocation) []types.PoolTxEvent {
 	txs, _ := m.poolTxs.lookupCopy(pool)
 	return txs
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -131,6 +131,8 @@ func (c *ControllerOverNetwork) IngestAggEvent(r tables.AggEvent) {
 		Base:    types.RequireEthAddr(r.Base),
 		Quote:   types.RequireEthAddr(r.Quote),
 	}
+
+	// TODO: this should acquire a lock if events can be added concurrently
 	hist := c.ctrl.cache.MaterializePoolTradingHist(pool)
 	hist.NextEvent(r)
 }

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -91,49 +91,64 @@ func (s *SubgraphSyncer) logSyncCycle(table string, nRows int) {
 func (s *SubgraphSyncer) syncStep(syncTime int) {
 	startTime := s.lastSyncTime + 1
 	doSyncFwd := true
+	uniswapCandles := true
 
-	s.cfg.Query = "./artifacts/graphQueries/balances.query"
-	tblBal := tables.BalanceTable{}
-	syncBal := loader.NewSyncChannel[tables.Balance, tables.BalanceSubGraph](
-		tblBal, s.cfg, s.cntr.IngestBalance)
-	nRows, _ := syncBal.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("User Balances", nRows)
+	if(uniswapCandles){
+		log.Printf("uniswapCandles: %s", uniswapCandles)
+		s.cfg.Query = "./artifacts/graphQueries/swaps.uniswap.query"
+		s.cfg.Chain.Subgraph = "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3"
+		tblAgg := tables.UniSwapsTable{}
+		syncAgg := loader.NewSyncChannel[tables.AggEvent, tables.UniSwapSubGraph](
+			tblAgg, s.cfg, s.cntr.IngestAggEvent)
+		log.Printf("Uniswap syncAgg: %s", syncAgg)
 
-	s.cfg.Query = "./artifacts/graphQueries/liqchanges.query"
-	tblLiq := tables.LiqChangeTable{}
-	syncLiq := loader.NewSyncChannel[tables.LiqChange, tables.LiqChangeSubGraph](
-		tblLiq, s.cfg, s.cntr.IngestLiqChange)
-	nRows, _ = syncLiq.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("LiqChanges", nRows)
+		nRows, _ := syncAgg.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("Poll Agg Events", nRows)
+	}else {	
 
-	s.cfg.Query = "./artifacts/graphQueries/swaps.query"
-	tblSwap := tables.SwapsTable{}
-	syncSwap := loader.NewSyncChannel[tables.Swap, tables.SwapSubGraph](
-		tblSwap, s.cfg, s.cntr.IngestSwap)
-	nRows, _ = syncSwap.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("Swaps", nRows)
+		s.cfg.Query = "./artifacts/graphQueries/balances.query"
+		tblBal := tables.BalanceTable{}
+		syncBal := loader.NewSyncChannel[tables.Balance, tables.BalanceSubGraph](
+			tblBal, s.cfg, s.cntr.IngestBalance)
+		nRows, _ := syncBal.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("User Balances", nRows)
 
-	s.cfg.Query = "./artifacts/graphQueries/knockoutcrosses.query"
-	tblKo := tables.KnockoutTable{}
-	syncKo := loader.NewSyncChannel[tables.KnockoutCross, tables.KnockoutCrossSubGraph](
-		tblKo, s.cfg, s.cntr.IngestKnockout)
-	nRows, _ = syncKo.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("Knockout crosses", nRows)
+		s.cfg.Query = "./artifacts/graphQueries/liqchanges.query"
+		tblLiq := tables.LiqChangeTable{}
+		syncLiq := loader.NewSyncChannel[tables.LiqChange, tables.LiqChangeSubGraph](
+			tblLiq, s.cfg, s.cntr.IngestLiqChange)
+		nRows, _ = syncLiq.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("LiqChanges", nRows)
 
-	s.cfg.Query = "./artifacts/graphQueries/feechanges.query"
-	tblFee := tables.FeeTable{}
-	syncFee := loader.NewSyncChannel[tables.FeeChange, tables.FeeChangeSubGraph](
-		tblFee, s.cfg, s.cntr.IngestFee)
-	nRows, _ = syncFee.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("Fee Changes", nRows)
+		s.cfg.Query = "./artifacts/graphQueries/swaps.query"
+		tblSwap := tables.SwapsTable{}
+		syncSwap := loader.NewSyncChannel[tables.Swap, tables.SwapSubGraph](
+			tblSwap, s.cfg, s.cntr.IngestSwap)
+		nRows, _ = syncSwap.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("Swaps", nRows)
 
-	s.cfg.Query = "./artifacts/graphQueries/aggevent.query"
-	tblAgg := tables.AggEventsTable{}
-	syncAgg := loader.NewSyncChannel[tables.AggEvent, tables.AggEventSubGraph](
-		tblAgg, s.cfg, s.cntr.IngestAggEvent)
-	nRows, _ = syncAgg.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
-	s.logSyncCycle("Poll Agg Events", nRows)
+		s.cfg.Query = "./artifacts/graphQueries/knockoutcrosses.query"
+		tblKo := tables.KnockoutTable{}
+		syncKo := loader.NewSyncChannel[tables.KnockoutCross, tables.KnockoutCrossSubGraph](
+			tblKo, s.cfg, s.cntr.IngestKnockout)
+		nRows, _ = syncKo.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("Knockout crosses", nRows)
 
+		s.cfg.Query = "./artifacts/graphQueries/feechanges.query"
+		tblFee := tables.FeeTable{}
+		syncFee := loader.NewSyncChannel[tables.FeeChange, tables.FeeChangeSubGraph](
+			tblFee, s.cfg, s.cntr.IngestFee)
+		nRows, _ = syncFee.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("Fee Changes", nRows)
+
+		s.cfg.Query = "./artifacts/graphQueries/aggevent.query"
+		tblAgg := tables.AggEventsTable{}
+		syncAgg := loader.NewSyncChannel[tables.AggEvent, tables.AggEventSubGraph](
+			tblAgg, s.cfg, s.cntr.IngestAggEvent)
+		nRows, _ = syncAgg.SyncTableToSubgraph(doSyncFwd, startTime, syncTime)
+		s.logSyncCycle("Poll Agg Events", nRows)
+
+	}
 	s.cntr.FlushSyncCycle(syncTime)
 	s.lastSyncTime = syncTime
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c h1:DZfsyhDK1hnSS
 github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=

--- a/loader/syncChannel.go
+++ b/loader/syncChannel.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/CrocSwap/graphcache-go/tables"
 	"github.com/CrocSwap/graphcache-go/types"
@@ -124,8 +125,8 @@ func (s *SyncChannel[R, S]) SyncTableToSubgraph(isAsc bool, startTime int, endTi
 		}
 
 		if nIngested > 0 {
-			log.Printf("Loaded %d rows from subgraph from query %s up to time=%d",
-				nIngested, s.config.Query, prevObs)
+			log.Printf("Loaded %d rows from subgraph from query %s up to time=%d - %s",
+				nIngested, s.config.Query, prevObs, time.Unix(int64(prevObs), 0).String())
 		}
 	}
 	return nIngested, nil

--- a/main.go
+++ b/main.go
@@ -7,9 +7,11 @@ import (
 	"github.com/CrocSwap/graphcache-go/controller"
 	"github.com/CrocSwap/graphcache-go/loader"
 	"github.com/CrocSwap/graphcache-go/server"
+	"github.com/CrocSwap/graphcache-go/utils"
 	"github.com/CrocSwap/graphcache-go/views"
 )
 
+var uniswapCandles = utils.GoDotEnvVariable("UNISWAP_CANDLES") == "true"
 func main() {
 	var netCfgPath = flag.String("netCfg", "./config/networks.json", "network config file")
 	flag.Parse()
@@ -21,7 +23,10 @@ func main() {
 	cntrl := controller.New(netCfg, cache)
 
 	for network, chainCfg := range netCfg {
-		controller.NewSubgraphSyncer(cntrl, chainCfg, network)
+		controller.NewSubgraphSyncer(cntrl, chainCfg, network, false)
+		if(uniswapCandles){
+			controller.NewSubgraphSyncer(cntrl, chainCfg, network, true)
+		}
 	}
 
 	views := views.Views{Cache: cache, OnChain: &onChain}

--- a/model/candle.go
+++ b/model/candle.go
@@ -19,12 +19,14 @@ type Candle struct {
 	PriceClose   float64 `json:"priceClose"`
 	MinPrice     float64 `json:"minPrice"`
 	MaxPrice     float64 `json:"maxPrice"`
+
 	VolumeBase   float64 `json:"volumeBase"`
 	VolumeQuote  float64 `json:"volumeQuote"`
 	TvlBase      float64 `json:"tvlBase"`
 	TvlQuote     float64 `json:"tvlQuote"`
 	FeeRateOpen  float64 `json:"feeRateOpen"`
 	FeeRateClose float64 `json:"feeRateClose"`
+	
 	Period       int     `json:"period"`
 	Time         int     `json:"time"`
 }
@@ -62,6 +64,7 @@ func (c *CandleBuilder) openCandle(accum AccumPoolStats, startTime int) {
 }
 
 func (c *CandleBuilder) Close(endTime int) []Candle {
+	// Question 6: Should this be an if statement?
 	for c.running.candle.Time+c.period < endTime {
 		c.closeCandle()
 	}
@@ -83,6 +86,7 @@ func (c *CandleBuilder) closeCandle() {
 }
 
 func (c *CandleBuilder) Increment(accum AccumPoolStats) {
+	// Question 6: Should this be an if statement? 
 	for accum.LatestTime >= c.running.candle.Time+c.period {
 		c.closeCandle()
 	}

--- a/model/liquidityHistory.go
+++ b/model/liquidityHistory.go
@@ -24,7 +24,7 @@ func (l *LiquidityDeltaHist) netCumulativeLiquidity() float64 {
 		totalLiq += delta.liqChange
 	}
 
-	if totalLiq < MIN_NUMERIC_STABLE_FLOW {
+	if totalLiq < getMinNumericStableFlow() {
 		return 0
 	}
 	return totalLiq
@@ -47,7 +47,7 @@ func (l *LiquidityDeltaHist) weightedAverageTime() int {
 
 		if delta.liqChange < 0 {
 			openLiq = openLiq + delta.liqChange
-			if openLiq < 0 || openLiq < MIN_NUMERIC_STABLE_FLOW {
+			if openLiq < 0 || openLiq < getMinNumericStableFlow() {
 				openLiq = 0
 			}
 		}

--- a/model/liquidityMath.go
+++ b/model/liquidityMath.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/CrocSwap/graphcache-go/tables"
+	"github.com/CrocSwap/graphcache-go/utils"
 )
 
 func deriveLiquidityFromAmbientFlow(baseFlow float64, quoteFlow float64) float64 {
@@ -87,16 +88,26 @@ func tickToPrice(tick int) float64 {
 	return math.Pow(1.0001, float64(tick))
 }
 
-const MIN_NUMERIC_STABLE_FLOW = 1000
+func getMinNumericStableFlow() float64 {
+	uniswapCandles := utils.GoDotEnvVariable("UNISWAP_CANDLES") == "true"
+	if(uniswapCandles){
+		return 0.01
+	} else {
+		return 1000
+	}
+}
+
+
+
 
 func isFlowNumericallyStable(baseFlow float64, quoteFlow float64) bool {
-	return math.Abs(baseFlow) >= MIN_NUMERIC_STABLE_FLOW ||
-		math.Abs(quoteFlow) >= MIN_NUMERIC_STABLE_FLOW
+	return math.Abs(baseFlow) >= getMinNumericStableFlow() ||
+		math.Abs(quoteFlow) >= getMinNumericStableFlow()
 }
 
 func isFlowDualStable(baseFlow float64, quoteFlow float64) bool {
-	return math.Abs(baseFlow) >= MIN_NUMERIC_STABLE_FLOW &&
-		math.Abs(quoteFlow) >= MIN_NUMERIC_STABLE_FLOW
+	return math.Abs(baseFlow) > getMinNumericStableFlow() &&
+		math.Abs(quoteFlow) > getMinNumericStableFlow()
 }
 
 func flowMagns(r *tables.LiqChange) (float64, float64) {

--- a/tables/uniSwaps.go
+++ b/tables/uniSwaps.go
@@ -1,0 +1,137 @@
+package tables
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+type UniSwapsTable struct{}
+
+func (tbl UniSwapsTable) GetID(r AggEvent) string {
+	return r.ID
+}
+
+func (tbl UniSwapsTable) GetTime(r AggEvent) int {
+	return r.Time
+}
+
+
+
+type UniSwapSubGraph struct {
+	ID              string `json:"id"`
+	Transaction	 struct {
+		ID string `json:"id"`
+		BlockNumber string `json:"blockNumber"`
+	}`json:"transaction"`
+
+	// EventIndex      int    `json:"eventIndex"`
+	Pool            struct {
+		ID string `json:"id"`
+		Token0 struct {
+			ID string `json:"id"`
+			Symbol string `json:"symbol"`
+		} `json:"token0"`
+		Token1 struct {
+			ID string `json:"id"`
+			Symbol string `json:"symbol"`
+		} `json:"token1"`
+		
+	} `json:"pool"`
+	Sender string `json:"sender"`
+	Recipient string `json:"recipient"`
+	Amount0      string `json:"amount0"`
+	Amount1     string `json:"amount1"`
+	Timestamp string `json:"timestamp"`
+
+}
+
+
+
+type UniSwapSubGraphData struct {
+	AggEvents []UniSwapSubGraph `json:"swaps"`
+}
+
+type UniSwapSubGraphResp struct {
+	Data UniSwapSubGraphData `json:"data"`
+}
+
+func (tbl UniSwapsTable) ConvertSubGraphRow(r UniSwapSubGraph, network string) AggEvent {
+	// positive one is base, negative one is quote
+
+	var baseFlow float64
+	var quoteFlow float64
+	var base string
+	var quote string
+
+	amount0 := parseNullableFloat64(r.Amount0)
+	amount1 := parseNullableFloat64(r.Amount1)
+	// Question 7: is this logic correct for determining base/quote?
+	if(*amount0 < 0){
+		base = r.Pool.Token0.ID
+		quote = r.Pool.Token1.ID
+		baseFlow = *amount0
+		quoteFlow = *amount1
+	}  else{
+		base = r.Pool.Token1.ID
+		quote = r.Pool.Token0.ID
+		baseFlow = *amount1
+		quoteFlow =  *amount0
+	}
+
+	// Flip is base/quote is actually reversed
+	// if strings.ToLower(base) > strings.ToLower(base) {
+	// 	base, quote = quote, base
+	// 	baseFlow, quoteFlow = quoteFlow, baseFlow
+	// }
+
+	price := math.Abs(baseFlow / quoteFlow)
+	// convert price to string
+	priceString := fmt.Sprintf("%f", price)
+
+	// convert pool.Id to int
+
+
+	return AggEvent{
+		ID:            network + r.ID,
+		EventIndex:    0,
+		Network:       network,
+		TX:            r.Transaction.ID,
+		Base:          base,
+		Quote:         quote,
+		PoolIdx:       420, // TODO: Replaced poolIDX with poolID
+		PoolHash:      r.Pool.ID,// TODO: Replaced poolIDX with poolID
+		Block:         parseInt(r.Transaction.BlockNumber),
+		Time:          parseInt(r.Timestamp),
+		BidTick:       0,
+		AskTick:       0,
+		SwapPrice:     priceString,
+		IsFeeChange:   false,
+		IsLiq:         false,
+		IsSwap:        true,
+		IsTickSkewed:  false,
+		InBaseQty:     true, //TODO: Confirm this is correct
+		FlowsAtMarket: false, // Only used in LiqTypes
+		FeeRate:       0,
+		BaseFlow:      baseFlow,
+		QuoteFlow:     quoteFlow,
+		Source:        "graph",
+	}
+}
+
+func (tbl UniSwapsTable) ParseSubGraphResp(body []byte) ([]UniSwapSubGraph, error) {
+	var parsed UniSwapSubGraphResp
+
+	err := json.Unmarshal(body, &parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]UniSwapSubGraph, 0)
+	for _, entry := range parsed.Data.AggEvents {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}
+
+func (tbl UniSwapsTable) SqlTableName() string { return "aggevents" }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+
+func GoDotEnvVariable(key string) (string) {
+	// load .env file
+	err := godotenv.Load(".env")
+	if err != nil {
+	  log.Fatalf("Error loading .env file")
+	}
+	return os.Getenv(key)
+  }

--- a/views/aggPool.go
+++ b/views/aggPool.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/CrocSwap/graphcache-go/model"
 	"github.com/CrocSwap/graphcache-go/types"
+	"github.com/CrocSwap/graphcache-go/utils"
 )
 
 func (v *Views) QueryPoolStats(chainId types.ChainId,
@@ -45,13 +46,22 @@ func (v *Views) QueryPoolCandles(chainId types.ChainId, base types.EthAddress, q
 		Base:    base,
 		Quote:   quote,
 	}
+	uniswapCandles := utils.GoDotEnvVariable("UNISWAP_CANDLES") == "true"
 
 	endTime := int(time.Now().Unix())
 	startTime := endTime - timeRange.N*timeRange.Period
+	
 
 	if timeRange.StartTime != nil {
-		startTime = *timeRange.StartTime
-		endTime = startTime + timeRange.N*timeRange.Period
+
+		if !uniswapCandles {
+			startTime = *timeRange.StartTime
+			endTime = startTime + timeRange.N*timeRange.Period			 
+		} else {
+			// Go in reverse from the starttime given
+			endTime = *timeRange.StartTime
+			startTime = endTime - timeRange.N*timeRange.Period
+		}
 	}
 
 	open, series := v.Cache.RetrievePoolAccumSeries(loc, startTime, endTime)

--- a/views/txHistory.go
+++ b/views/txHistory.go
@@ -34,7 +34,7 @@ func (v *Views) QueryPoolTxHist(chainId types.ChainId,
 		Base:    base,
 		Quote:   quote,
 	}
-	results := v.Cache.RetrivePoolTxs(loc)
+	results := v.Cache.RetrievePoolTxs(loc)
 	sort.Sort(byTimeTx(results))
 
 	if len(results) < nResults {


### PR DESCRIPTION
Create a .env file and add the var: `UNISWAP_CANDLES=true` 
This will run the repo in such a way that only the swaps from uniswap syncs and no other data is pulled.  This is meant to be run alongside the normal implementation of graphcache-go to supplement candles from other pools and historical data. Candles will be found at the same endpoint when run in this mode. 

Some estimates:
My initial estimates seemed to indicate that the amount of memory the process will take up should stick under 10GB for the next while.  It will probably take several hours to crawl back over the uniswap swaps until it hits January 1, 2023.  

Changes: 
1.   syncs all pools backward from the time started and pools forward into the future.  Implemented with 2 subgraphSyncer objects that run concurrently. 
2. Can no longer rely on `tradingHistory.TimeSnaps` to be in order, so sorting is done on fetch of candles
3. Runs the sort on `TimeSnaps` even in normal mode - technically adds unnecessary operation, but still seems about the same on my machine.   Felt that the guarantee of being sorted was worth the negligible latency increase. 
4. Added launch.json file to use vscode debugger - feel free to remove and put in gitignore
5. added a field called "isDecimalized" to each candle for FE interpretation - note that uniswap candles are already decimalized. 
6. Added Utils package for fetching env vars

Questions/Concerns:
1. Since we're adding historical data and polling into the future at the same time, it seems possible that trading history could create a race condition. Is it necessary to add a lock here?  Look for TODO to see comment about it. 
2. Since uniswap `WETH/USDC` pools have different ids in uniswap, the quote/base are flipped. Also, they have different ids on uniswap, so this may need to be accounted for in the FE. 
3. Might make sense to slow the polling period to focus on fetching historical data first. 
4. Since historical and present data are fetched syncronously, there might be issues with trading history accumulative values.  Since this is only used for candles, it shouldn't make a difference.  
5. would be good to store the historical swaps into a JSON dump file so that they can be ingested directly if the system ever resets.  As is, it would mean we're stuck crawling back via subgraph requests. 

FE TODOs:
1. Interpret the isDecimalized field and apply appropriate changes
2. Fetch from the correct api for uniswap candles
3. Factor in any ids that may be different between crocswap and uniswap (i.e. WETH) 



Notes: 
if you just want to test the usdc/weth pool, then add this line into the where clause of the uniswaps.swaps.query file:
```
    pool_in: ["0x7bea39867e4169dbe237d55c8242a8f2fcdcc387", "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8", "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", "0xe0554a476a092703abdb3ef35c80e0d76d32939f"]
```

This is a good way to quickly get a bunch of data for a single pool and test the candles.  

