### PR TITLE
fix issue w/ QueryPoolSet where chain was being ignored

### DIFF
--- a/views/aggPool.go
+++ b/views/aggPool.go
@@ -69,7 +69,7 @@ func (v *Views) QueryPoolSet(chainId types.ChainId) []types.PoolLocation {
 	poolSet := make([]types.PoolLocation, 0)
 	for _, pool := range fullSet {
 		if pool.ChainId == chainId {
-			poolSet = append(fullSet, pool)
+			poolSet = append(poolSet, pool)
 		}
 	}
 


### PR DESCRIPTION
Fixed logical issue that ignore the chainId in filtering pool list. 

Note:  There are some examples in postman of accepting a `poolIdx` field, but this is not supported in this endpoint. Should it be? 


Closes #6 