### PR TITLE
Fix derivePriceFromConcFlow formula

### DIFF
--- a/model/liquidityMath.go
+++ b/model/liquidityMath.go
@@ -66,7 +66,7 @@ func deriveRootFromInRange(baseFlow float64, quoteFlow float64,
 
 	solutionPos := (-termB + math.Sqrt(termB*termB-4*termA*termC)) /
 		(2 * termA)
-	solutionNeg := (-termB + math.Sqrt(termB*termB-4*termA*termC)) /
+	solutionNeg := (-termB - math.Sqrt(termB*termB-4*termA*termC)) /
 		(2 * termA)
 
 	if solutionPos >= bidPrice && solutionPos <= askPrice {


### PR DESCRIPTION
The formula was wrong before.
To test:
To check the issue in prod, go to https://ambindexer.net/gcgo/pool_stats?chainId=0x1&base=0x0000000000000000000000000000000000000000&quote=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&poolIdx=420&histTime=1687234799
and see that the result was 1310 for lastPriceIndic

After this fix, if you run the go server, you can make a request to:
http://localhost:8080/gcgo/pool_stats?chainId=0x1&base=0x0000000000000000000000000000000000000000&quote=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&poolIdx=420&histTime=1687234799
and you should see the price be in the "usual" range
