### PR TITLE
Create user_pool_txs route

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ func (s *APIWebServer) Serve() {
 	r.GET("gcgo/user_limit_orders", s.queryUserLimits)
 	r.GET("gcgo/pool_limit_orders", s.queryPoolLimits)
 	r.GET("gcgo/user_pool_limit_orders", s.queryUserPoolLimits)
+	r.GET("gcgo/user_pool_txs", s.queryUserPoolTxHist)
 	r.GET("gcgo/limit_stats", s.querySingleLimit)
 	r.GET("gcgo/user_txs", s.queryUserTxHist)
 	r.GET("gcgo/pool_txs", s.queryPoolTxHist)
@@ -263,6 +264,21 @@ func (s *APIWebServer) queryUserPoolLimits(c *gin.Context) {
 	}
 
 	resp := s.Views.QueryUserPoolLimits(chainId, user, base, quote, poolIdx)
+	wrapDataErrResp(c, resp, nil)
+}
+
+func (s *APIWebServer) queryUserPoolTxHist(c *gin.Context) {
+	chainId := parseChainParam(c, "chainId")
+	user := parseAddrParam(c, "user")
+	base := parseAddrParam(c, "base")
+	quote := parseAddrParam(c, "quote")
+	poolIdx := parseIntParam(c, "poolIdx")
+
+	if len(c.Errors) > 0 {
+		return
+	}
+
+	resp := s.Views.QueryUserPoolTxHist(chainId, user, base, quote, poolIdx)
 	wrapDataErrResp(c, resp, nil)
 }
 

--- a/views/txHistory.go
+++ b/views/txHistory.go
@@ -25,6 +25,24 @@ func (v *Views) QueryUserTxHist(chainId types.ChainId, user types.EthAddress, nR
 	}
 }
 
+func (v *Views) QueryUserPoolTxHist(chainId types.ChainId, user types.EthAddress,base types.EthAddress, quote types.EthAddress, poolIdx int) []UserTxHistory {
+	results := v.Cache.RetrieveUserTxs(chainId, user)
+	var filteredResults []types.PoolTxEvent
+	loc := types.PoolLocation{
+		ChainId: chainId,
+		PoolIdx: poolIdx,
+		Base:    base,
+		Quote:   quote,
+	}
+	for _, tx := range results {
+		if tx.PoolLocation == loc {
+			filteredResults = append(filteredResults, tx)
+		}
+	}
+	sort.Sort(byTimeTx(filteredResults))
+	return appendTags(filteredResults)
+}
+
 func (v *Views) QueryPoolTxHist(chainId types.ChainId,
 	base types.EthAddress, quote types.EthAddress, poolIdx int, nResults int) []UserTxHistory {
 

--- a/views/views.go
+++ b/views/views.go
@@ -28,6 +28,9 @@ type IViews interface {
 	QueryUserPoolLimits(chainId types.ChainId, user types.EthAddress,
 		base types.EthAddress, quote types.EthAddress,
 		poolIdx int) []UserLimitOrder
+	QueryUserPoolTxHist(chainId types.ChainId, user types.EthAddress,
+		base types.EthAddress, quote types.EthAddress,
+		poolIdx int) []UserTxHistory
 	QuerySingleLimit(chainId types.ChainId, user types.EthAddress,
 		base types.EthAddress, quote types.EthAddress,
 		poolIdx int, bidTick int, askTick int, isBid bool, pivotTime int) *UserLimitOrder


### PR DESCRIPTION
Closes #21 

Adds a route for `user_pool_txs`

To test: 
1. Run Server
2. Nav to example url
3. inspect response and confirm txs are correct

Example url: 

http://localhost:8080/gcgo/user_pool_txs?chainId=0x1&user=0x5edfda7a115584df2912ac1fd55197079e060fe8&base=0x0000000000000000000000000000000000000000&quote=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&poolIdx=420


Response:

```
{
    "data": [
        {
            "blockNum": 17753902,
            "txHash": "0x302c2c8dd54e9c11b2e57a10e6ca4c6037c54e8214f80790a4046cb7191e6718",
            "txTime": 1690092179,
            "user": "0x5edfda7a115584df2912ac1fd55197079e060fe8",
            "chainId": "0x1",
            "base": "0x0000000000000000000000000000000000000000",
            "quote": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
            "poolIdx": 420,
            "baseFlow": -19884298160836400,
            "quoteFlow": -37926548,
            "entityType": "liqchange",
            "changeType": "burn",
            "positionType": "concentrated",
            "bidTick": 199968,
            "askTick": 201984,
            "isBuy": false,
            "inBaseQty": false,
            "txId": "tx_67554209438a3fe9f49c42aacbb7198b10f5052e2c961c87db90b1d9e50d40b3"
        },
        {
            "blockNum": 17569747,
            "txHash": "0x3e2cfce830032f2f88571ce1f8e278e48565949390c241f6a7f5852a4e768d65",
            "txTime": 1687857215,
            "user": "0x5edfda7a115584df2912ac1fd55197079e060fe8",
            "chainId": "0x1",
            "base": "0x0000000000000000000000000000000000000000",
            "quote": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
            "poolIdx": 420,
            "baseFlow": 19680724239582656,
            "quoteFlow": 37289581,
            "entityType": "liqchange",
            "changeType": "mint",
            "positionType": "concentrated",
            "bidTick": 199968,
            "askTick": 201984,
            "isBuy": false,
            "inBaseQty": false,
            "txId": "tx_662f2534c95b1fe04c2765fcf27994c953354d3d6dce2d864e401cbe57a91fb3"
        },
        {
            "blockNum": 17569742,
            "txHash": "0xca0a5a061ddb011bf5aa99c8605015955dba4858e351dc1101b66ef8375aaf3d",
            "txTime": 1687857155,
            "user": "0x5edfda7a115584df2912ac1fd55197079e060fe8",
            "chainId": "0x1",
            "base": "0x0000000000000000000000000000000000000000",
            "quote": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
            "poolIdx": 420,
            "baseFlow": 0,
            "quoteFlow": 15000000,
            "entityType": "limitOrder",
            "changeType": "mint",
            "positionType": "knockout",
            "bidTick": 201104,
            "askTick": 201120,
            "isBuy": false,
            "inBaseQty": false,
            "txId": "tx_6ec182b21212e05ba84dde1ac0ce2c89ec8a5951cf6e53350136edef1434980b"
        },
        {
            "blockNum": 17569709,
            "txHash": "0x2149fbc404cb0dd0bd29e65b93368687ff2fb59fd8761625e74c7c76a7c498a0",
            "txTime": 1687856759,
            "user": "0x5edfda7a115584df2912ac1fd55197079e060fe8",
            "chainId": "0x1",
            "base": "0x0000000000000000000000000000000000000000",
            "quote": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
            "poolIdx": 420,
            "baseFlow": -22369275397963576,
            "quoteFlow": 42000000,
            "entityType": "swap",
            "changeType": "swap",
            "positionType": "swap",
            "bidTick": 0,
            "askTick": 0,
            "isBuy": false,
            "inBaseQty": false,
            "txId": "tx_254fc36cc5950273428d25da594958fee319d5f2d69455429050b33afa3d796c"
        }
    ],
    "provenance": {
        "hostname": "Cades-M2-Air.local",
        "serveTime": 1692730697487
    }
}
```