### PR TITLE
Multicall optimization

### DIFF
--- a/artifacts/abis/Multicall.json
+++ b/artifacts/abis/Multicall.json
@@ -1,0 +1,440 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "returnData",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowFailure",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call3[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate3",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowFailure",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call3Value[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate3Value",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "blockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBasefee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "basefee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "chainid",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockCoinbase",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockDifficulty",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "difficulty",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "gaslimit",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getEthBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryAggregate",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryBlockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall3.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/config/networks.json
+++ b/config/networks.json
@@ -4,6 +4,7 @@
     "rpc": "https://mainnet.infura.io/v3/4741d1713bff4013bc3075ed6e7ce091",
     "subgraph": "https://api.thegraph.com/subgraphs/name/crocswap/croc-mainnet",
     "query_contract": "0xc2e1f740E11294C64adE66f69a1271C5B32004c8",
+    "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "knockout_tick_width": 16
   }
 }

--- a/config/networksWithTest.json
+++ b/config/networksWithTest.json
@@ -4,6 +4,7 @@
     "rpc": "https://goerli.infura.io/v3/4741d1713bff4013bc3075ed6e7ce091",
     "subgraph": "https://api.thegraph.com/subgraphs/name/crocswap/croc-testnet",
     "query_contract": "0x49281c10c66f217705b4aa108e59785c6b6bc39e",
+    "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "knockout_tick_width": 64
   },
 
@@ -12,6 +13,7 @@
     "rpc": "https://mainnet.infura.io/v3/4741d1713bff4013bc3075ed6e7ce091",
     "subgraph": "https://api.thegraph.com/subgraphs/name/crocswap/croc-mainnet",
     "query_contract": "0xc2e1f740E11294C64adE66f69a1271C5B32004c8",
+    "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "knockout_tick_width": 16
   }
 }

--- a/config/scroll.json
+++ b/config/scroll.json
@@ -4,6 +4,8 @@
       "rpc": "https://rpc.scroll.io",
       "subgraph": "https://api.studio.thegraph.com/query/47610/croc-scroll/version/latest",
       "query_contract": "0x62223e90605845Cf5CC6DAE6E0de4CDA130d6DDf",
+      "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "multicall_max_batch": 40,
       "knockout_tick_width": 4
     }
   }

--- a/config/scroll.json
+++ b/config/scroll.json
@@ -4,8 +4,10 @@
       "rpc": "https://rpc.scroll.io",
       "subgraph": "https://api.studio.thegraph.com/query/47610/croc-scroll/version/latest",
       "query_contract": "0x62223e90605845Cf5CC6DAE6E0de4CDA130d6DDf",
+      "knockout_tick_width": 4,
+      "multicall_disabled": false,
       "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
       "multicall_max_batch": 40,
-      "knockout_tick_width": 4
+      "multicall_interval_ms": 500
     }
   }

--- a/config/scrollTestnet.json
+++ b/config/scrollTestnet.json
@@ -4,6 +4,7 @@
       "rpc": "https://sepolia-rpc.scroll.io",
       "subgraph": "https://api.studio.thegraph.com/query/47610/croc-scroll-sepolia/v0.1.4",
       "query_contract": "0x43eC1302FE3587862e15B2D52AD9653575FD79e9",
+      "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
       "knockout_tick_width": 1
     }
   }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,8 +18,7 @@ type Controller struct {
 	workers *workers
 }
 
-func New(netCfg loader.NetworkConfig, cache *cache.MemoryCache) *Controller {
-	chain := &loader.OnChainLoader{Cfg: netCfg}
+func New(netCfg loader.NetworkConfig, cache *cache.MemoryCache, chain *loader.OnChainLoader) *Controller {
 	query := loader.NewCrocQuery(chain)
 
 	return NewOnQuery(netCfg, cache, query)

--- a/loader/chain.go
+++ b/loader/chain.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/CrocSwap/graphcache-go/types"
 	"github.com/ethereum/go-ethereum"
@@ -12,8 +15,62 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+type Call3InputType struct {
+	Target       common.Address
+	AllowFailure bool
+	CallData     []byte
+}
+
+type Call3OutputType struct {
+	Success    bool
+	ReturnData []uint8
+}
+
+type CallJob struct {
+	Contract types.EthAddress
+	CallData []byte
+	Result   chan []byte
+}
+
 type OnChainLoader struct {
-	Cfg NetworkConfig
+	Cfg           NetworkConfig
+	JobChans      map[int]chan CallJob
+	BatchInterval time.Duration
+	multicallAbi  abi.ABI
+}
+
+func NewOnChainLoader(cfg NetworkConfig) *OnChainLoader {
+	chans := make(map[int]chan CallJob)
+	for _, chain := range cfg {
+		chans[chain.ChainID] = make(chan CallJob)
+	}
+
+	c := &OnChainLoader{
+		Cfg:           cfg,
+		JobChans:      chans,
+		BatchInterval: time.Duration(500) * time.Millisecond,
+		multicallAbi:  multicallAbi(),
+	}
+	for key, chain := range cfg {
+		go c.multicallWorker(chain.ChainID, key)
+	}
+	return c
+}
+
+func multicallAbi() abi.ABI {
+	filePath := "./artifacts/abis/Multicall.json"
+	file, err := os.Open(filePath)
+
+	if err != nil {
+		log.Fatalf("Failed to read ABI contract at " + filePath)
+	}
+
+	parsedABI, err := abi.JSON(file)
+	if err != nil {
+		log.Fatalf("Failed to parse contract ABI: %v", err)
+	}
+
+	return parsedABI
 }
 
 func (c *OnChainLoader) ethClientForChain(chainId types.ChainId) (*ethclient.Client, error) {
@@ -34,19 +91,19 @@ func (c *OnChainLoader) ethClientForChain(chainId types.ChainId) (*ethclient.Cli
 	return client, err
 }
 
-func callContractKey(methodName string, token types.EthAddress, client *ethclient.Client, abi abi.ABI) (interface{}, error) {
+func (c *OnChainLoader) callContractKey(methodName string, token types.EthAddress, client *ethclient.Client, chainId types.ChainId, abi abi.ABI) (interface{}, error) {
 	callData, err := abi.Pack(methodName)
 	if err != nil {
 		log.Fatalf("Failed to parse method %s on ABI", methodName)
 	}
-	result, err := callContractFn(callData, methodName, token, client, abi)
+	result, err := c.callContractFn(callData, methodName, token, client, chainId, abi)
 	return result[0], err
 }
 
-func callContractFn(callData []byte, methodName string,
-	contract types.EthAddress, client *ethclient.Client, abi abi.ABI) ([]interface{}, error) {
+func (c *OnChainLoader) callContractFn(callData []byte, methodName string,
+	contract types.EthAddress, client *ethclient.Client, chainId types.ChainId, abi abi.ABI) ([]interface{}, error) {
 
-	result, err := contractDataCall(client, contract, callData)
+	result, err := c.contractDataCall(client, chainId, contract, callData)
 	if err != nil {
 		log.Printf("Warning calling %s() on contract "+err.Error(), methodName)
 		return nil, err
@@ -60,17 +117,132 @@ func callContractFn(callData []byte, methodName string,
 	return unparsed, nil
 }
 
-func contractDataCall(client *ethclient.Client, contract types.EthAddress, data []byte) ([]byte, error) {
-	addr := common.HexToAddress(string(contract))
+func (c *OnChainLoader) contractDataCall(client *ethclient.Client, chainId types.ChainId, contract types.EthAddress, data []byte) ([]byte, error) {
+	job := CallJob{
+		Contract: contract,
+		CallData: data,
+		Result:   make(chan []byte, 1),
+	}
+	chainIdInt, _ := strconv.ParseInt(string(chainId)[2:], 16, 32)
+	c.JobChans[int(chainIdInt)] <- job
 
+	// Wait for the multicall result and fall back to a direct call if it times out
+	select {
+	case result := <-job.Result:
+		if len(result) == 0 {
+			return []byte{}, fmt.Errorf("empty result from multicall, error")
+		}
+		return result, nil
+	case <-time.After(2000 * time.Millisecond):
+		log.Println("Multicall timed out, sending manually")
+		addr := common.HexToAddress(string(contract))
+
+		msg := ethereum.CallMsg{
+			To:   &addr,
+			Data: data,
+		}
+
+		result, err := client.CallContract(context.Background(), msg, nil)
+		if err != nil {
+			return []byte{}, err
+		}
+		return result, nil
+	}
+}
+
+// Goroutine that aggregates calls and sends them to the multicall contract after a timeout
+func (c *OnChainLoader) multicallWorker(chainId int, networkName types.NetworkName) {
+	jobChan := c.JobChans[chainId]
+	jobs := make([]CallJob, 0)
+	batchTimer := time.NewTimer(1<<63 - 1)
+	maxBatchSize := c.Cfg[networkName].MulticallMaxBatch
+	if maxBatchSize == 0 {
+		maxBatchSize = 10
+	}
+
+	log.Println("multicallWorker started", chainId, networkName, "maxBatchSize", maxBatchSize, "batchInterval", c.BatchInterval)
+
+	for {
+		// Timer starts as soon as the first job is received.
+		// If the timer finishes or the batch is full, the batch is sent.
+		select {
+		case job := <-jobChan:
+			if len(jobs) == 0 {
+				batchTimer.Reset(c.BatchInterval)
+			}
+			jobs = append(jobs, job)
+			if len(jobs) < maxBatchSize {
+				continue
+			}
+		case <-batchTimer.C:
+		}
+		batchTimer.Reset(1<<63 - 1)
+
+		err := c.multicall(jobs, chainId, networkName)
+		// Cancel all jobs if the multicall fails
+		if err != nil {
+			for _, job := range jobs {
+				job.Result <- []byte{}
+			}
+		}
+		jobs = jobs[:0]
+	}
+}
+
+// Sends a batch of calls to the multicall contract
+func (c *OnChainLoader) multicall(jobs []CallJob, chainId int, networkName types.NetworkName) (err error) {
+	defer func() {
+		if err := recover(); err != nil {
+			err = fmt.Sprintln("multicall panic", err)
+		}
+	}()
+
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	inputs := make([]Call3InputType, len(jobs))
+	for i, job := range jobs {
+		input := Call3InputType{
+			Target:       common.HexToAddress(string(job.Contract)),
+			AllowFailure: true,
+			CallData:     job.CallData,
+		}
+		inputs[i] = input
+	}
+	packed, err := c.multicallAbi.Pack("aggregate3", inputs)
+	if err != nil {
+		log.Fatal("failed to pack aggregate3", err)
+	}
+
+	addr := common.HexToAddress(c.Cfg[networkName].MulticallContract)
 	msg := ethereum.CallMsg{
 		To:   &addr,
-		Data: data,
+		Data: packed,
 	}
 
-	result, err := client.CallContract(context.Background(), msg, nil)
+	client, err := c.ethClientForChain(types.IntToChainId(chainId))
 	if err != nil {
-		return []byte{}, err
+		return err
 	}
-	return result, nil
+	multicallResult, err := client.CallContract(context.Background(), msg, nil)
+	if err != nil {
+		return err
+	}
+
+	var results []Call3OutputType
+	err = c.multicallAbi.UnpackIntoInterface(&results, "aggregate3", multicallResult)
+	if err != nil {
+		log.Fatal("failed to unpack aggregate3", err)
+	}
+
+	for i, job := range jobs {
+		result := results[i]
+		if result.Success {
+			job.Result <- result.ReturnData
+		} else {
+			job.Result <- []byte{}
+		}
+	}
+	return nil
 }

--- a/loader/crocQuery.go
+++ b/loader/crocQuery.go
@@ -156,7 +156,7 @@ func (q *CrocQuery) callQueryResults(chainId types.ChainId,
 		return make([]interface{}, 0), err
 	}
 
-	return callContractFn(callData, methodName, contractAddr, client, q.queryAbi)
+	return q.chain.callContractFn(callData, methodName, contractAddr, client, chainId, q.queryAbi)
 }
 
 func (q *CrocQuery) callQueryFirstReturn(chainId types.ChainId,

--- a/loader/networkConfig.go
+++ b/loader/networkConfig.go
@@ -11,15 +11,17 @@ import (
 )
 
 type ChainConfig struct {
-	NetworkName       string
-	ChainID           int    `json:"chain_id"`
-	RPCEndpoint       string `json:"rpc"`
-	Subgraph          string `json:"subgraph"`
-	QueryContract     string `json:"query_contract"`
-	MulticallContract string `json:"multicall_contract"`
-	MulticallMaxBatch int    `json:"multicall_max_batch"`
-	QueryContractABI  string `json:"query_contract_abi"`
-	KnockoutTickWidth int    `json:"knockout_tick_width"`
+	NetworkName         string
+	ChainID             int    `json:"chain_id"`
+	RPCEndpoint         string `json:"rpc"`
+	Subgraph            string `json:"subgraph"`
+	QueryContract       string `json:"query_contract"`
+	QueryContractABI    string `json:"query_contract_abi"`
+	KnockoutTickWidth   int    `json:"knockout_tick_width"`
+	MulticallDisabled   bool   `json:"multicall_disabled"`
+	MulticallContract   string `json:"multicall_contract"`
+	MulticallMaxBatch   int    `json:"multicall_max_batch"`
+	MulticallIntervalMs int    `json:"multicall_interval_ms"`
 }
 
 type NetworkConfig map[types.NetworkName]ChainConfig

--- a/loader/networkConfig.go
+++ b/loader/networkConfig.go
@@ -16,6 +16,8 @@ type ChainConfig struct {
 	RPCEndpoint       string `json:"rpc"`
 	Subgraph          string `json:"subgraph"`
 	QueryContract     string `json:"query_contract"`
+	MulticallContract string `json:"multicall_contract"`
+	MulticallMaxBatch int    `json:"multicall_max_batch"`
 	QueryContractABI  string `json:"query_contract_abi"`
 	KnockoutTickWidth int    `json:"knockout_tick_width"`
 }

--- a/main.go
+++ b/main.go
@@ -17,10 +17,10 @@ func main() {
 	flag.Parse()
 
 	netCfg := loader.LoadNetworkConfig(*netCfgPath)
-	onChain := loader.OnChainLoader{Cfg: netCfg}
+	onChain := loader.NewOnChainLoader(netCfg)
 
 	cache := cache.New()
-	cntrl := controller.New(netCfg, cache)
+	cntrl := controller.New(netCfg, cache, onChain)
 
 	if *noRpcMode {
 		nonQuery := loader.NonCrocQuery{}
@@ -31,7 +31,7 @@ func main() {
 		controller.NewSubgraphSyncer(cntrl, chainCfg, network)
 	}
 
-	views := views.Views{Cache: cache, OnChain: &onChain}
+	views := views.Views{Cache: cache, OnChain: onChain}
 	apiServer := server.APIWebServer{Views: &views}
 	apiServer.Serve(*apiPath)
 }


### PR DESCRIPTION
This is my take on a [multicall](https://github.com/mds1/multicall) optimization for the indexer. It's transparent to the callers of the chain loader - it only affects its internals and the outside code is largely untouched.

Batch scheduling is very simple - there's a limit of the number of calls in a batch and a time limit after which it stops waiting for more calls to fill the batch. The first request in a batch will potentially have to wait that whole time until batch processing starts. But since these calls are periodic instead of interactive and most of the time batches get fully filled, I don't think the added delay is an issue.

As far as I can tell, no errors or changes in behavior occur because of this optimization. If multicall execution times out for some reason, there's a fallback to a normal direct contract call. So even if the multicall worker crashes there will only be a performance degradation, not a catastrophic failure.

In batches of 40 calls per request (~30KB payloads), the Scroll indexer averages ~1.6 `eth_call` requests per second. With Ankr's pricing that comes out to ~$3 per day.

Multicall mode can optionally be configured or disabled for each chain separately, the configuration has safe defaults that should work with any RPC provider. It's enabled by default with batch size of 10 and interval of 500ms. At least the batch size should be tuned for each provider.

I tested Ankr's Scroll endpoint and it had no issues with batches of 40 calls after running for multiple hours without errors, aside from a couple multicall timeouts. But Ankr has throttling so that large requests aren't processed faster than many small ones. I also quickly tested BlockPi and it doesn't seem to throttle and it can go much faster even on a free endpoint.

Even though Ankr is throttling multicall requests, I don't think the indexer is falling behind. Some data from the test runs:

|              | Time running | `eth_call` requests | Liquidity refreshes | Liq refresh / s | Liq refresh / call | RPC cost per day |
|--------------|--------------|---------------------|---------------------|-----------------|--------------------|-------------------|
| Normal       | 4515s        | 290445              | 152700              | 33.8            | 0.52               | $111              |
| Batched (40) | 24690s       | 38752               | 796300              | 32.2            | 20.5               | $2.7              |

These numbers were obtained using a simple RPC proxy and confirmed by the usage data on Ankr's dashboard (the cost is based on Ankr's price of $0.00002 per call). Basically the same number of liquidity refreshes (taken from the indexer itself) per second, only 40 times more efficient per `eth_call`, so the batched mode isn't lagging behind.

Also, in general, it seems like the indexer is too eager to refresh everything even when nothing has happened to the contract. Not 100% sure about that and haven't looked at that part of the code, but it might warrant tuning to improve efficiency even more.

Potential improvements:
- Add multicall timeout parameter to the configuration, currently it's hardcoded to 2 seconds.
- Remove unused multicall ABI methods as only `aggregate3` is used. Currently the ABI is included verbatim.
- Handle zero byte contract return values. Currently a zero byte return is a signal that this specific call failed as part of a multicall batch. But I think that's a valid return value for contract functions, though `CrocQuery` never returns that, to my knowledge.
