### PR TITLE
Optimize request latency

### DIFF
--- a/cache/rwMap.go
+++ b/cache/rwMap.go
@@ -1,6 +1,9 @@
 package cache
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 type RWLockMap[Key comparable, Val any] struct {
 	entries map[Key]Val
@@ -64,6 +67,22 @@ func (m *RWLockMapArray[Key, Val]) lookupCopy(key Key) ([]Val, bool) {
 	return retVal, ok
 }
 
+func (m *RWLockMapArray[Key, Val]) lookupLastN(key Key, lastN int) ([]Val, bool) {
+	var retVal []Val
+	m.lock.RLock()
+	result, ok := m.entries[key]
+	if ok {
+		if len(result) < lastN {
+			lastN = len(result)
+		}
+
+		retVal = append(retVal, result[len(result)-lastN:]...)
+	}
+	m.lock.RUnlock()
+	slices.Reverse(retVal)
+	return retVal, ok
+}
+
 func (m *RWLockMapMap[Key, KeyInner, Val]) lookupSet(key Key) (map[KeyInner]Val, bool) {
 	var retVal map[KeyInner]Val = make(map[KeyInner]Val, 0)
 	m.lock.RLock()
@@ -85,11 +104,26 @@ func (m *RWLockMap[Key, Val]) insert(key Key, val Val) {
 
 func (m *RWLockMapArray[Key, Val]) insert(key Key, val Val) {
 	m.lock.Lock()
-	result, ok := m.entries[key]
-	if !ok {
-		m.entries[key] = make([]Val, 0)
+	m.entries[key] = append(m.entries[key], val)
+	m.lock.Unlock()
+}
+
+func (m *RWLockMapArray[Key, Val]) insertSorted(key Key, val Val, less func(i, j Val) bool) {
+	m.lock.Lock()
+	result := m.entries[key]
+	var i int
+	for i = len(result) - 1; i >= 0; i-- {
+		if less(val, result[i]) {
+			break
+		}
 	}
-	m.entries[key] = append(result, val)
+	i += 1
+
+	var zero Val
+	result = append(result, zero)
+	copy(result[i+1:], result[i:])
+	result[i] = val
+	m.entries[key] = result
 	m.lock.Unlock()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/CrocSwap/graphcache-go
 go 1.20
 
 require (
-	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/ethereum/go-ethereum v1.11.6
 	github.com/gin-gonic/gin v1.9.0
 	github.com/miguelmota/go-solidity-sha3 v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
-github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08 h1:ox2F0PSMlrAAiAdknSRMDrAr8mfxPCfSZolH+/qQnyQ=
-github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/cockroachdb/errors v1.9.1 h1:yFVvsI0VxmRShfawbt/laCIDy/mtTqqnvoNgiy5bEV8=
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZeQy818SGhaone5OnYfxFR/+AzdY3sf5aE=
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoGMWEhDvS3zToKcDpRsLuRolQJBVGdozk=

--- a/types/exchangeTxs.go
+++ b/types/exchangeTxs.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+)
+
 type PoolTxEvent struct {
 	EthTxHeader
 	PoolLocation
@@ -31,4 +37,28 @@ type PoolRangeFields struct {
 	AskTick   int  `json:"askTick"`
 	IsBuy     bool `json:"isBuy"`
 	InBaseQty bool `json:"inBaseQty"`
+}
+
+func (p PoolTxEvent) Hash() [32]byte {
+	buf := new(bytes.Buffer)
+	buf.Grow(270)
+	binary.Write(buf, binary.BigEndian, int32(p.BlockNum))
+	buf.WriteString(string(p.TxHash))
+	binary.Write(buf, binary.BigEndian, int32(p.TxTime))
+	buf.WriteString(string(p.User))
+
+	buf.WriteString(string(p.ChainId))
+	buf.WriteString(string(p.Base))
+	buf.WriteString(string(p.Quote))
+	binary.Write(buf, binary.BigEndian, int32(p.PoolIdx))
+
+	buf.WriteString(string(p.EntityType))
+	buf.WriteString(string(p.ChangeType))
+	buf.WriteString(string(p.PositionType))
+
+	binary.Write(buf, binary.BigEndian, int32(p.BidTick))
+	binary.Write(buf, binary.BigEndian, int32(p.AskTick))
+	binary.Write(buf, binary.BigEndian, p.IsBuy)
+	binary.Write(buf, binary.BigEndian, p.InBaseQty)
+	return sha256.Sum256(buf.Bytes())
 }

--- a/types/locations.go
+++ b/types/locations.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+)
+
 type PoolLocation struct {
 	ChainId ChainId    `json:"chainId"`
 	Base    EthAddress `json:"base"`
@@ -70,6 +76,35 @@ func (l PositionLocation) ToBookLoc() BookLocation {
 		l.PoolLocation,
 		l.LiquidityLocation,
 	}
+}
+
+func (p PositionLocation) Hash() [32]byte {
+	buf := new(bytes.Buffer)
+	buf.Grow(160)
+	buf.WriteString(string(p.ChainId))
+	buf.WriteString(string(p.Base))
+	buf.WriteString(string(p.Quote))
+	binary.Write(buf, binary.BigEndian, int32(p.PoolIdx))
+	binary.Write(buf, binary.BigEndian, int32(p.BidTick))
+	binary.Write(buf, binary.BigEndian, int32(p.AskTick))
+	binary.Write(buf, binary.BigEndian, p.IsBid)
+	buf.WriteString(string(p.User))
+	return sha256.Sum256(buf.Bytes())
+}
+
+func (k KOClaimLocation) Hash() [32]byte {
+	buf := new(bytes.Buffer)
+	buf.Grow(160)
+	buf.WriteString(string(k.ChainId))
+	buf.WriteString(string(k.Base))
+	buf.WriteString(string(k.Quote))
+	binary.Write(buf, binary.BigEndian, int32(k.PoolIdx))
+	binary.Write(buf, binary.BigEndian, int32(k.BidTick))
+	binary.Write(buf, binary.BigEndian, int32(k.AskTick))
+	binary.Write(buf, binary.BigEndian, k.IsBid)
+	buf.WriteString(string(k.User))
+	binary.Write(buf, binary.BigEndian, int32(k.PivotTime))
+	return sha256.Sum256(buf.Bytes())
 }
 
 func (l BookLocation) ToPositionLocation(user EthAddress) PositionLocation {

--- a/views/limits.go
+++ b/views/limits.go
@@ -1,14 +1,10 @@
 package views
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"log"
 	"math/big"
 	"sort"
-
-	"github.com/cnf/structhash"
 
 	"github.com/CrocSwap/graphcache-go/model"
 	"github.com/CrocSwap/graphcache-go/types"
@@ -138,8 +134,8 @@ func unrollSubplot(pos types.PositionLocation, subplot *model.KnockoutSubplot) [
 }
 
 func formLimitId(loc types.KOClaimLocation) string {
-	hash := sha256.Sum256(structhash.Dump(loc, 1))
-	return fmt.Sprintf("limit_%s", hex.EncodeToString(hash[:]))
+	hash := loc.Hash()
+	return "limit_" + hex.EncodeToString(hash[:])
 }
 
 type byTimeLO []UserLimitOrder

--- a/views/txHistory.go
+++ b/views/txHistory.go
@@ -49,14 +49,8 @@ func (v *Views) QueryPoolTxHist(chainId types.ChainId,
 		Base:    base,
 		Quote:   quote,
 	}
-	results := v.Cache.RetrivePoolTxs(loc)
-	sort.Sort(byTimeTx(results))
-
-	if len(results) < nResults {
-		return appendTags(results)
-	} else {
-		return appendTags(results[0:nResults])
-	}
+	results := v.Cache.RetriveLastNPoolTxs(loc, nResults)
+	return appendTags(results)
 }
 
 func (v *Views) QueryPoolTxHistFrom(chainId types.ChainId,

--- a/views/txHistory.go
+++ b/views/txHistory.go
@@ -1,13 +1,10 @@
 package views
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"sort"
 
 	"github.com/CrocSwap/graphcache-go/types"
-	"github.com/cnf/structhash"
 )
 
 type UserTxHistory struct {
@@ -25,7 +22,7 @@ func (v *Views) QueryUserTxHist(chainId types.ChainId, user types.EthAddress, nR
 	}
 }
 
-func (v *Views) QueryUserPoolTxHist(chainId types.ChainId, user types.EthAddress,base types.EthAddress, quote types.EthAddress, poolIdx int) []UserTxHistory {
+func (v *Views) QueryUserPoolTxHist(chainId types.ChainId, user types.EthAddress, base types.EthAddress, quote types.EthAddress, poolIdx int) []UserTxHistory {
 	results := v.Cache.RetrieveUserTxs(chainId, user)
 	var filteredResults []types.PoolTxEvent
 	loc := types.PoolLocation{
@@ -94,8 +91,8 @@ func appendTags(txs []types.PoolTxEvent) []UserTxHistory {
 }
 
 func formTxId(loc types.PoolTxEvent) string {
-	hash := sha256.Sum256(structhash.Dump(loc, 1))
-	return fmt.Sprintf("tx_%s", hex.EncodeToString(hash[:]))
+	hash := loc.Hash()
+	return "tx_" + hex.EncodeToString(hash[:])
 }
 
 type byTimeTx []types.PoolTxEvent


### PR DESCRIPTION
Firstly, this PR removes dependency on `structhash` for generating IDs for positions, limit orders, and transactions. Instead a buffer is manually filled with all the relevant fields and hashed. This noticeably speeds up requests with a lot of these IDs, mostly `pool_positions` (down to ~30ms from ~90ms).

But the slowest request by far is `pool_txs` because it retrieves all transactions and then sorts them before returning a handful of TXs which were sent most recently. But the transactions get inserted into memory cache in an almost sorted order already, and they're never sorted in any other way. 

So the second change of this PR is to maintain the order during insertion, and retrieve the last rows directly. This brings the latency of `pool_txs` request down to less than 1ms compared to 150-300ms currently.

Future optimizations:
1. The same ordering optimization should be applied to pool positions, but they're currently stored in a map and also they'll require re-sorting on every update since they're sorted by last update time. Not as trivial, but inevitable as the state will keep growing.
2. `pool_txs` with `time` parameter still takes longer than it reasonably should (200-300ms), but not 5 seconds like it used to. Though it's very rarely used.