### PR TITLE
Add historic positions method

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	var swapStart = flag.Int("swapStart", 0, "Block number to start swap event processing")
 	var aggStart = flag.Int("aggStart", 0, "Block number to start aggregate event processing")
 	var balStart = flag.Int("balStart", 0, "Block number to start user balance processing")
+	var extendedApi = flag.Bool("extendedApi", false, "Expose additional methods in the API")
 
 	flag.Parse()
 
@@ -50,5 +51,5 @@ func main() {
 
 	views := views.Views{Cache: cache, OnChain: onChain}
 	apiServer := server.APIWebServer{Views: &views}
-	apiServer.Serve(*apiPath)
+	apiServer.Serve(*apiPath, *extendedApi)
 }

--- a/model/aprCalc.go
+++ b/model/aprCalc.go
@@ -21,7 +21,7 @@ func (p *PositionTracker) CalcAPR(loc types.PositionLocation) APRCalcResult {
 
 	numerator := p.aprNumerator(loc)
 	denom := p.aprDenominator()
-	time := p.liqHist.weightedAverageDuration()
+	time := p.LiqHist.weightedAverageDuration()
 
 	apy := normalizeApr(numerator, denom, time)
 	return APRCalcResult{
@@ -45,7 +45,7 @@ func (p *PositionTracker) aprDenominator() float64 {
 	if p.IsConcentrated() {
 		return castBigToFloat(&p.ConcLiq)
 	} else {
-		return p.liqHist.netCumulativeLiquidity()
+		return p.LiqHist.netCumulativeLiquidity()
 	}
 }
 

--- a/model/liquidityHistory.go
+++ b/model/liquidityHistory.go
@@ -8,20 +8,20 @@ import (
 )
 
 type LiquidityDeltaHist struct {
-	hist []LiquidityDelta
+	Hist []LiquidityDelta `json:"hist"`
 }
 
 type LiquidityDelta struct {
-	time         int
-	liqChange    float64
+	Time         int
+	LiqChange    float64
 	resetRewards bool
 }
 
 func (l *LiquidityDeltaHist) netCumulativeLiquidity() float64 {
 	totalLiq := 0.0
 
-	for _, delta := range l.hist {
-		totalLiq += delta.liqChange
+	for _, delta := range l.Hist {
+		totalLiq += delta.LiqChange
 	}
 
 	if totalLiq < MIN_NUMERIC_STABLE_FLOW {
@@ -40,25 +40,25 @@ func (l *LiquidityDeltaHist) weightedAverageTime() int {
 	openLiq := 0.0
 	openTime := 0.0
 
-	for _, delta := range l.hist {
+	for _, delta := range l.Hist {
 		if delta.resetRewards == true {
-			openTime = float64(delta.time)
+			openTime = float64(delta.Time)
 		}
 
-		if delta.liqChange < 0 {
-			openLiq = openLiq + delta.liqChange
+		if delta.LiqChange < 0 {
+			openLiq = openLiq + delta.LiqChange
 			if openLiq < 0 || openLiq < MIN_NUMERIC_STABLE_FLOW {
 				openLiq = 0
 			}
 		}
 
-		if delta.liqChange > 0 {
-			weight := openLiq / (openLiq + delta.liqChange)
-			openTime = openTime*weight + float64(delta.time)*(1.0-weight)
+		if delta.LiqChange > 0 {
+			weight := openLiq / (openLiq + delta.LiqChange)
+			openTime = openTime*weight + float64(delta.Time)*(1.0-weight)
 		}
 
-		if delta.liqChange == 0 && openLiq == 0 {
-			openTime = float64(delta.time)
+		if delta.LiqChange == 0 && openLiq == 0 {
+			openTime = float64(delta.Time)
 		}
 	}
 	return int(openTime)
@@ -69,8 +69,8 @@ func (l *LiquidityDeltaHist) appendChange(r tables.LiqChange) {
 	l.assertTimeForward(r.Time)
 
 	if r.ChangeType == "harvest" {
-		l.hist = append(l.hist, LiquidityDelta{
-			time:         r.Time,
+		l.Hist = append(l.Hist, LiquidityDelta{
+			Time:         r.Time,
 			resetRewards: true,
 		})
 
@@ -78,29 +78,29 @@ func (l *LiquidityDeltaHist) appendChange(r tables.LiqChange) {
 		liqMagn := determineLiquidityMagn(r)
 
 		if r.ChangeType == "mint" {
-			l.hist = append(l.hist, LiquidityDelta{
-				time:      r.Time,
-				liqChange: liqMagn})
+			l.Hist = append(l.Hist, LiquidityDelta{
+				Time:      r.Time,
+				LiqChange: liqMagn})
 
 		} else if r.ChangeType == "burn" {
-			l.hist = append(l.hist, LiquidityDelta{
-				time:      r.Time,
-				liqChange: -liqMagn})
+			l.Hist = append(l.Hist, LiquidityDelta{
+				Time:      r.Time,
+				LiqChange: -liqMagn})
 		}
 	}
 }
 
 func (l *LiquidityDeltaHist) initHist() {
-	if l.hist == nil {
-		l.hist = make([]LiquidityDelta, 0)
+	if l.Hist == nil {
+		l.Hist = make([]LiquidityDelta, 0)
 	}
 }
 
 func (l *LiquidityDeltaHist) assertTimeForward(time int) {
-	if len(l.hist) == 0 {
+	if len(l.Hist) == 0 {
 		return
 	}
-	lastTime := l.hist[0].time
+	lastTime := l.Hist[0].Time
 
 	if time < lastTime {
 		log.Fatalf("Liquidity delta history has backward time step %d->%d", lastTime, time)

--- a/model/position.go
+++ b/model/position.go
@@ -14,7 +14,7 @@ type PositionTracker struct {
 	FirstMintTx      string `json:"firstMintTx"`
 	PositionType     string `json:"positionType"`
 	PositionLiquidity
-	liqHist LiquidityDeltaHist
+	LiqHist LiquidityDeltaHist `json:"-"`
 }
 
 func (p *PositionTracker) UpdatePosition(l tables.LiqChange) {
@@ -32,7 +32,7 @@ func (p *PositionTracker) UpdatePosition(l tables.LiqChange) {
 	}
 	p.PositionType = l.PositionType
 
-	p.liqHist.appendChange(l)
+	p.LiqHist.appendChange(l)
 }
 
 func (p *PositionTracker) UpdateAmbient(liq big.Int) {

--- a/model/tradingHistory.go
+++ b/model/tradingHistory.go
@@ -100,7 +100,7 @@ func (a *AccumPoolStats) accumSwapType(e tables.AggEvent) {
 	}
 
 	if isStable {
-		price := derivePriceFromAmbientFlow(math.Abs(e.BaseFlow), math.Abs(e.QuoteFlow))
+		price := derivePriceFromSwapFlow(math.Abs(e.BaseFlow), math.Abs(e.QuoteFlow), a.FeeRate, e.BaseFlow < 0)
 		a.LastPriceSwap = price
 		a.LastPriceIndic = price
 	}

--- a/views/views.go
+++ b/views/views.go
@@ -21,6 +21,8 @@ type IViews interface {
 	QuerySinglePosition(chainId types.ChainId, user types.EthAddress,
 		base types.EthAddress, quote types.EthAddress,
 		poolIdx int, bidTick int, askTick int) *UserPosition
+	QueryHistoricPositions(chainId types.ChainId, base types.EthAddress, quote types.EthAddress,
+		poolIdx int, time int, user types.EthAddress, omitEmpty bool) []HistoricUserPosition
 
 	QueryUserLimits(chainId types.ChainId, user types.EthAddress) []UserLimitOrder
 	QueryPoolLimits(chainId types.ChainId, base types.EthAddress, quote types.EthAddress,


### PR DESCRIPTION
Add `-extendedApi` flag to expose a method to query historic positions. Because the quality of its output relies on the swap price in the pool trading history, that price now takes the pool's fee rate into account. That doesn't solve all issues with this method of calculating historic pool state, but it makes a noticeable improvement for liquid stable pools (and also makes the charts smoother).