### PR TITLE
Add initTime to pool_stats

### DIFF
--- a/cache/transactors.go
+++ b/cache/transactors.go
@@ -132,6 +132,18 @@ func (m *MemoryCache) RetrievePoolAccum(loc types.PoolLocation) model.AccumPoolS
 	return pos.StatsCounter
 }
 
+func (m *MemoryCache) RetrievePoolAccumFirst(loc types.PoolLocation) model.AccumPoolStats {
+	pos, okay := m.poolTradingHistory.lookup(loc)
+	if !okay {
+		return model.AccumPoolStats{}
+	}
+	if len(pos.TimeSnaps) == 0 {
+		return pos.StatsCounter
+	} else {
+		return pos.TimeSnaps[0]
+	}
+}
+
 type AccumTagged struct {
 	model.AccumPoolStats
 	types.PoolLocation

--- a/model/tradingHistory.go
+++ b/model/tradingHistory.go
@@ -30,7 +30,7 @@ func NewPoolTradingHistory() *PoolTradingHistory {
 }
 
 func (h *PoolTradingHistory) NextEvent(r tables.AggEvent) {
-	if r.Time != h.StatsCounter.LatestTime {
+	if r.Time != h.StatsCounter.LatestTime && h.StatsCounter.LatestTime != 0 {
 		h.TimeSnaps = append(h.TimeSnaps, h.StatsCounter)
 	}
 	h.StatsCounter.Accumulate(r)

--- a/views/aggPool.go
+++ b/views/aggPool.go
@@ -7,8 +7,13 @@ import (
 	"github.com/CrocSwap/graphcache-go/types"
 )
 
+type PoolStats struct {
+	InitTime int `json:"initTime"`
+	model.AccumPoolStats
+}
+
 func (v *Views) QueryPoolStats(chainId types.ChainId,
-	base types.EthAddress, quote types.EthAddress, poolIdx int) model.AccumPoolStats {
+	base types.EthAddress, quote types.EthAddress, poolIdx int) PoolStats {
 
 	loc := types.PoolLocation{
 		ChainId: chainId,
@@ -16,11 +21,18 @@ func (v *Views) QueryPoolStats(chainId types.ChainId,
 		Base:    base,
 		Quote:   quote,
 	}
-	return v.Cache.RetrievePoolAccum(loc)
+
+	accum := v.Cache.RetrievePoolAccum(loc)
+	firstAccum := v.Cache.RetrievePoolAccumFirst(loc)
+
+	return PoolStats{
+		InitTime:       firstAccum.LatestTime,
+		AccumPoolStats: accum,
+	}
 }
 
 func (v *Views) QueryPoolStatsFrom(chainId types.ChainId,
-	base types.EthAddress, quote types.EthAddress, poolIdx int, histTime int) model.AccumPoolStats {
+	base types.EthAddress, quote types.EthAddress, poolIdx int, histTime int) PoolStats {
 
 	loc := types.PoolLocation{
 		ChainId: chainId,
@@ -28,7 +40,13 @@ func (v *Views) QueryPoolStatsFrom(chainId types.ChainId,
 		Base:    base,
 		Quote:   quote,
 	}
-	return v.Cache.RetrievePoolAccumBefore(loc, histTime)
+	accum := v.Cache.RetrievePoolAccumBefore(loc, histTime)
+	firstAccum := v.Cache.RetrievePoolAccumFirst(loc)
+
+	return PoolStats{
+		InitTime:       firstAccum.LatestTime,
+		AccumPoolStats: accum,
+	}
 }
 
 type CandleRangeArgs struct {

--- a/views/views.go
+++ b/views/views.go
@@ -47,9 +47,9 @@ type IViews interface {
 		poolIdx int) PoolLiqCurve
 
 	QueryPoolStats(chainId types.ChainId, base types.EthAddress, quote types.EthAddress,
-		poolIdx int) model.AccumPoolStats
+		poolIdx int) PoolStats
 	QueryPoolStatsFrom(chainId types.ChainId, base types.EthAddress, quote types.EthAddress,
-		poolIdx int, histTime int) model.AccumPoolStats
+		poolIdx int, histTime int) PoolStats
 	QueryChainStats(chainId types.ChainId, nResults int) []TokenDexAgg
 
 	QueryPoolCandles(chainId types.ChainId, base types.EthAddress, quote types.EthAddress, poolIdx int,


### PR DESCRIPTION
Add `initTime` field to `pool_stats` response. It returns the time of the first stats accumulator in the pool trading history.

The only "unintended" change of this patch is the fact that the first zeroed out stats accumulator won't be appended to the beginning of the `TimeSnaps` list. I don't think it was necessary, doesn't seem to change anything.

Fixes #37 