### PR TITLE
Upgrade to The Graph Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ After building to run, from the project root directory call
 
 ## Network options
 
-By default the instance uses the network config at `./config/networks.json`. To use a different configuration file run with
+By default the instance uses the network config at `./config/ethereum.json`. To use a different configuration file run with
 
 `./graphcache-go -netCfg [NETWORK_CONFIG_PATH]`
 

--- a/config/blast.json
+++ b/config/blast.json
@@ -2,7 +2,7 @@
     "blast": {
       "chain_id": 81457,
       "rpc": "",
-      "subgraph": "https://api.studio.thegraph.com/query/47610/croc-blast-spare/v0.2.13",
+      "subgraph": "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/6zckS6hnNXpUcyZ4Jk9aQZcJ9UvWUFy8Mfhm6xPEPac3",
       "query_contract": "0xA3BD3bE19012De72190c885FB270beb93e36a8A7",
       "knockout_tick_width": 4,
       "multicall_disabled": false,

--- a/config/blastNoMulticall.json
+++ b/config/blastNoMulticall.json
@@ -2,7 +2,7 @@
     "blast": {
       "chain_id": 81457,
       "rpc": "",
-      "subgraph": "https://api.studio.thegraph.com/query/47610/croc-blast/v0.1.0",
+      "subgraph": "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/6zckS6hnNXpUcyZ4Jk9aQZcJ9UvWUFy8Mfhm6xPEPac3",
       "query_contract": "0xA3BD3bE19012De72190c885FB270beb93e36a8A7",
       "knockout_tick_width": 4,
       "multicall_disabled": true

--- a/config/ethereum.json
+++ b/config/ethereum.json
@@ -2,7 +2,7 @@
   "mainnet": {
     "chain_id": 1,
     "rpc": "https://mainnet.infura.io/v3/4741d1713bff4013bc3075ed6e7ce091",
-    "subgraph": "https://api.studio.thegraph.com/query/47610/croc-mainnet/v0.15",
+    "subgraph": "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/DyHaLYK1keqcv3YD3VczKGYvxQGfGgV6bGTbZLMj5xME",
     "query_contract": "0xc2e1f740E11294C64adE66f69a1271C5B32004c8",
     "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "multicall_max_batch": 50,

--- a/config/ethereumWithTest.json
+++ b/config/ethereumWithTest.json
@@ -7,11 +7,11 @@
     "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "knockout_tick_width": 64
   },
-  
+
   "mainnet": {
     "chain_id": 1,
     "rpc": "https://mainnet.infura.io/v3/4741d1713bff4013bc3075ed6e7ce091",
-    "subgraph": "https://api.thegraph.com/subgraphs/name/crocswap/croc-mainnet",
+    "subgraph": "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/DyHaLYK1keqcv3YD3VczKGYvxQGfGgV6bGTbZLMj5xM",
     "query_contract": "0xc2e1f740E11294C64adE66f69a1271C5B32004c8",
     "multicall_contract": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "knockout_tick_width": 16

--- a/config/scroll.json
+++ b/config/scroll.json
@@ -2,7 +2,7 @@
     "scroll": {
       "chain_id": 534352,
       "rpc": "https://rpc.scroll.io",
-      "subgraph": "https://api.studio.thegraph.com/query/47610/croc-scroll/v0.1.0",
+      "subgraph": "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/59jR4oDLQrg8eJRGqX4BoYoeLiomfPBcG83Urut2C7Ec",
       "query_contract": "0x62223e90605845Cf5CC6DAE6E0de4CDA130d6DDf",
       "knockout_tick_width": 4,
       "multicall_disabled": false,

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	var netCfgPath = flag.String("netCfg", "./config/networks.json", "network config file")
+	var netCfgPath = flag.String("netCfg", "./config/ethereum.json", "network config file")
 	var apiPath = flag.String("apiPath", "gcgo", "API server root path")
 	var noRpcMode = flag.Bool("noRpcMode", false, "Run in mode with no RPC calls")
 	var swapStart = flag.Int("swapStart", 0, "Block number to start swap event processing")


### PR DESCRIPTION
Changes:
1. Support new subgraph URLs with the API key passed as `GRAPH_API_KEY` environment variable.
2. Add additional error handling to query response parsing.
3. Move `config/networks.json` to `config/ethereum.json`.