### PR TITLE
Add combined query subgraph syncer and startup cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM golang:1.22
 WORKDIR /app/
 
 COPY go.mod go.sum ./
-RUN go mod download 
+RUN go mod download
 
 COPY ./ /app/
 RUN go build
+RUN go build ./cmd/startupCacher
 
 EXPOSE 8080
 ENTRYPOINT ["/app/graphcache-go"]

--- a/artifacts/graphQueries/combined.query
+++ b/artifacts/graphQueries/combined.query
@@ -1,0 +1,118 @@
+query($swapMinBlock: BigInt, $swapMaxBlock: BigInt, $aggMinBlock: BigInt, $aggMaxBlock: BigInt,
+      $liqMinBlock: BigInt, $liqMaxBlock: BigInt, $koMinBlock: BigInt, $koMaxBlock: BigInt,
+      $feeMinBlock: BigInt, $feeMaxBlock: BigInt, $balMinBlock: BigInt, $balMaxBlock: BigInt,
+      $orderDir: OrderDirection) {
+  _meta {
+    block {
+      hash
+      number
+      timestamp
+    }
+  },
+  swaps(first: 1000, where: { block_gte: $swapMinBlock, block_lte: $swapMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    transactionHash
+    callIndex
+    user
+    pool {
+      base
+      quote
+      poolIdx
+    }
+    block
+    time
+    isBuy
+    inBaseQty
+    qty
+    limitPrice
+    minOut
+    baseFlow
+    quoteFlow
+  },
+  aggEvents(first: 1000, where: { block_gte: $aggMinBlock, block_lte: $aggMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    pool {
+      base
+      quote
+      poolIdx
+    }
+    block
+    time
+    bidTick
+    askTick
+    swapPrice
+    inBaseQty
+    isSwap
+    isLiq
+    isFeeChange
+    baseFlow
+    quoteFlow
+    feeRate
+    isTickSkewed
+    flowsAtMarket
+  },
+  liquidityChanges(first: 1000, where: { block_gte: $liqMinBlock, block_lte: $liqMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    transactionHash
+    callIndex
+    user
+    pool {
+      base
+      quote
+      poolIdx
+    }
+    block
+    time
+    positionType
+    changeType
+    bidTick
+    askTick
+    isBid
+    liq
+    baseFlow
+    quoteFlow
+    pivotTime
+  },
+  knockoutCrosses(first: 1000, where: { block_gte: $koMinBlock, block_lte: $koMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    transactionHash
+    pool {
+      base
+      quote
+      poolIdx
+    }
+    block
+    time
+    tick
+    isBid
+    pivotTime
+    feeMileage
+  },
+  feeChanges(first: 1000, where:  { block_gte: $feeMinBlock, block_lte: $feeMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    transactionHash
+    callIndex
+    block
+    time
+    pool {
+      base
+      quote
+      poolIdx
+    }
+    feeRate
+  },
+  userBalances(first: 1000, where: { block_gte: $balMinBlock, block_lte: $balMaxBlock },
+    orderBy: block, orderDirection: $orderDir) {
+    id
+    transactionHash
+    block
+    time
+    user
+    token
+  }
+}

--- a/cmd/startupCacher/main.go
+++ b/cmd/startupCacher/main.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/CrocSwap/graphcache-go/loader"
+	"github.com/CrocSwap/graphcache-go/types"
+)
+
+type CacheMeta struct {
+	ChainID  types.ChainId `json:"chain_id"`
+	Subgraph string        `json:"subgraph"`
+	// Cache includes everything until MaxBlock for each table (inclusive)
+	MaxBlocks loader.SubgraphStartBlocks `json:"max_blocks"`
+}
+
+type TableState struct {
+	QueryMinBlock *int
+	ObsIds        map[string]struct{}
+}
+
+// Attempt to refresh the cache every 4 hours (though it will still be updated only if there's more than a day's worth of data).
+const CACHE_UPDATE_INTERVAL = 4 * time.Hour
+
+const MAX_BLOCK = 999999999
+
+// Since we need to both partially parse and re-serialize rows from different tables, we need
+// to dynamically unmarshal them and then parse `id` and `time` fields.
+// Serializing them back is needed because we can't just dump raw query results, we need to
+// group them in chunks.
+type Entry map[string]json.RawMessage
+
+// Reads data from the subgraph and caches it in a directory structure like:
+// `{startupCacheDir}/{chainId}/{table}/{table}_{firstBlockOfChunk}-{lastBlockOfChunk}.json`
+// Will only retrieve day-sized chunks of data that are at least 24 hours old to
+// prevent caching bad data.
+func startupCacher(cfg loader.ChainConfig, startupCacheDir string, wg *sync.WaitGroup) {
+	defer func() {
+		wg.Done()
+		if r := recover(); r != nil {
+			log.Printf("Cacher for %d recovered from panic: %s", cfg.ChainID, r)
+		}
+	}()
+
+	chainId := types.IntToChainId(cfg.ChainID)
+	syncCfg := loader.SyncChannelConfig{
+		Chain:   cfg,
+		Network: types.NetworkName(cfg.NetworkName),
+	}
+
+	chainPath := filepath.Join(startupCacheDir, string(chainId))
+	meta, tableStates, err := loadMeta(startupCacheDir, chainId)
+	if err != nil {
+		log.Printf("Error loading cache meta for chain %s: %s", chainId, err)
+		return
+	}
+	meta.Subgraph = cfg.Subgraph
+
+	now := time.Now().UTC()
+	stopDate := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).Add(-24 * time.Hour)
+	log.Printf("Caching data for chain %s from %v", chainId, meta.MaxBlocks)
+	meta.ChainID = types.IntToChainId(cfg.ChainID)
+	meta.Subgraph = cfg.Subgraph
+
+	minBlocks := &meta.MaxBlocks
+
+	tableEntries := make(map[string][]Entry)
+	for {
+		log.Printf("Querying subgraph for chain %s, blocks: Swap: %d Agg: %d Bal: %d Liq: %d Ko: %d Fee: %d", chainId, minBlocks.Swaps, minBlocks.Aggs, minBlocks.Bal, minBlocks.Liq, minBlocks.Ko, minBlocks.Fee)
+		_, combined, err := loader.CombinedQuery(syncCfg, *minBlocks, MAX_BLOCK)
+		if err != nil {
+			log.Printf("Error querying subgraph for chain %s, retrying: %s", chainId, err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		if combined.Meta.Block.Number == 0 {
+			log.Printf("Warning subgraph for chain %s latest block is 0, retrying", chainId)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		tables := map[string]*json.RawMessage{
+			"swaps":            &combined.Swaps,
+			"aggEvents":        &combined.Aggs,
+			"userBalances":     &combined.Bals,
+			"feeChanges":       &combined.Fees,
+			"knockoutCrosses":  &combined.Kos,
+			"liquidityChanges": &combined.Liqs,
+		}
+
+		anyTableHasMore := false
+		for tableName, tableData := range tables {
+			entries := make([]Entry, 0)
+			err = json.Unmarshal(*tableData, &entries)
+			if err != nil {
+				log.Printf("Error unmarshalling %s data for chain %s: %s", tableName, chainId, err)
+				anyTableHasMore = true
+				continue
+			}
+			if len(entries) == 0 {
+				log.Printf("Warning subgraph for chain %s for table %s returned no entries while at least one was expected", chainId, tableName)
+				anyTableHasMore = true
+				continue
+			}
+			for _, entry := range entries {
+				entryId, entryTime, entryBlock := parseEntryFields(entry)
+
+				if entryTime.Before(stopDate) {
+
+					if _, seen := tableStates[tableName].ObsIds[entryId]; !seen {
+						// log.Println(entryTime, day, entryBlock, tableName, entryId)
+						tableEntries[tableName] = append(tableEntries[tableName], entry)
+						tableStates[tableName].ObsIds[entryId] = struct{}{}
+						anyTableHasMore = true
+					}
+					if entryBlock > *tableStates[tableName].QueryMinBlock {
+						*tableStates[tableName].QueryMinBlock = entryBlock
+					}
+				}
+			}
+		}
+
+		tableLengths := map[string]int{
+			"swaps":            len(tableStates["swaps"].ObsIds),
+			"aggEvents":        len(tableStates["aggEvents"].ObsIds),
+			"userBalances":     len(tableStates["userBalances"].ObsIds),
+			"feeChanges":       len(tableStates["feeChanges"].ObsIds),
+			"knockoutCrosses":  len(tableStates["knockoutCrosses"].ObsIds),
+			"liquidityChanges": len(tableStates["liquidityChanges"].ObsIds),
+		}
+
+		log.Println("Table lengths for", chainId, tableLengths)
+		saveChunks(&tableEntries, string(chainId), chainPath, false)
+		if !anyTableHasMore {
+			log.Printf("Finished querying %s: Swap: %d Agg: %d Bal: %d Liq: %d Ko: %d Fee: %d", chainId, minBlocks.Swaps, minBlocks.Aggs, minBlocks.Bal, minBlocks.Liq, minBlocks.Ko, minBlocks.Fee)
+			break
+		}
+	}
+
+	saveChunks(&tableEntries, string(chainId), chainPath, true)
+
+	meta.MaxBlocks = *minBlocks
+	metaData, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		log.Printf("Error marshalling cache meta data for chain %s: %s", chainId, err)
+		return
+	}
+	saveToFile(metaData, chainPath, "meta.json")
+
+	runtime.GC()
+	log.Printf("Chain %s cache updated to %s", chainId, stopDate)
+}
+
+// Bigger files make more sense but they take longer to load because of insertion sorting.
+const ENTRIES_PER_FILE = 3000
+
+// Saves chunks to storage, either all of them if `saveAll` is `true` or only until
+// less than `ENTRIES_PER_FILE` entries are left.
+func saveChunks(tableEntries *map[string][]Entry, chainId string, chainPath string, saveAll bool) {
+	for tableName, entries := range *tableEntries {
+		tablePath := filepath.Join(chainPath, tableName)
+		if len(entries) == 0 || (len(entries) < ENTRIES_PER_FILE && !saveAll) {
+			continue
+		}
+
+		err := os.MkdirAll(tablePath, 0755)
+		if err != nil {
+			log.Printf("Error creating directory for chain %s for table %s: %s", chainId, tableName, err)
+			continue
+		}
+
+		// Write entries as chunks of ENTRIES_PER_FILE entries
+		remainingEntries := entries
+		for {
+			entryCount := min(ENTRIES_PER_FILE, len(remainingEntries))
+			savingChunk := remainingEntries[:entryCount]
+			_, _, firstBlock := parseEntryFields(savingChunk[0])
+			_, _, lastBlock := parseEntryFields(savingChunk[len(savingChunk)-1])
+
+			tableData, err := json.MarshalIndent(savingChunk, "", " ")
+			if err != nil {
+				log.Printf("Error marshalling entries for chain %s, table %s %d-%d: %s", chainId, tableName, firstBlock, lastBlock, err)
+				continue
+			}
+			chunkFilename := fmt.Sprintf("%s_%d-%d.json", tableName, firstBlock, lastBlock)
+			log.Printf("Saving entries for chain %s, table %s %d-%d to %s", chainId, tableName, firstBlock, lastBlock, chunkFilename)
+			saveToFile(tableData, tablePath, chunkFilename)
+			remainingEntries = remainingEntries[entryCount:]
+			if (len(remainingEntries) < ENTRIES_PER_FILE && !saveAll) || (len(remainingEntries) == 0) {
+				break
+			}
+		}
+		// To *really* deallocate saved entries
+		remainingCopy := make([]Entry, len(remainingEntries))
+		copy(remainingCopy, remainingEntries)
+		clear((*tableEntries)[tableName])
+		delete(*tableEntries, tableName)
+		(*tableEntries)[tableName] = remainingCopy
+		runtime.GC()
+	}
+}
+
+func saveToFile(data []byte, directory string, filename string) (err error) {
+	tablePathTemp := filepath.Join(directory, "."+filename)
+	err = os.WriteFile(tablePathTemp, data, 0644)
+	if err != nil {
+		log.Printf("Error writing data to file %s: %s", tablePathTemp, err)
+		return
+	}
+	err = os.Rename(tablePathTemp, filepath.Join(directory, filename))
+	if err != nil {
+		log.Printf("Error renaming file %s: %s", tablePathTemp, err)
+		return
+	}
+	return
+}
+
+// Loads chain meta from storage. Can take minutes for large chains.
+func loadMeta(startupCacheDir string, chainId types.ChainId) (metaPtr *CacheMeta, states map[string]TableState, err error) {
+	log.Printf("Loading meta for chain %s", chainId)
+	var meta CacheMeta
+	metaPtr = &meta
+	meta.ChainID = chainId
+	states = map[string]TableState{
+		"swaps":            {QueryMinBlock: &meta.MaxBlocks.Swaps, ObsIds: make(map[string]struct{}, 100000)},
+		"aggEvents":        {QueryMinBlock: &meta.MaxBlocks.Aggs, ObsIds: make(map[string]struct{}, 100000)},
+		"userBalances":     {QueryMinBlock: &meta.MaxBlocks.Bal, ObsIds: make(map[string]struct{}, 100000)},
+		"feeChanges":       {QueryMinBlock: &meta.MaxBlocks.Fee, ObsIds: make(map[string]struct{})},
+		"knockoutCrosses":  {QueryMinBlock: &meta.MaxBlocks.Ko, ObsIds: make(map[string]struct{})},
+		"liquidityChanges": {QueryMinBlock: &meta.MaxBlocks.Liq, ObsIds: make(map[string]struct{}, 100000)},
+	}
+
+	loadableTableNames := []string{}
+	files, err := os.ReadDir(filepath.Join(startupCacheDir, string(chainId)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return metaPtr, states, nil
+		}
+		log.Println("Error reading chain directory:", err)
+		return nil, nil, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			if _, ok := states[file.Name()]; ok {
+				loadableTableNames = append(loadableTableNames, file.Name())
+			}
+		}
+	}
+
+	for _, tableName := range loadableTableNames {
+		tablePath := filepath.Join(startupCacheDir, string(chainId), tableName)
+		files, err := os.ReadDir(tablePath)
+		if err != nil {
+			log.Printf("Error reading table %s for chain %s: %s", tableName, chainId, err)
+			continue
+		}
+		tableChunks := make([]string, 0)
+		for _, file := range files {
+			if !file.IsDir() && strings.HasPrefix(file.Name(), tableName+"_") {
+				tableChunks = append(tableChunks, file.Name())
+			}
+		}
+		slices.Sort(tableChunks)
+		table := states[tableName]
+
+		for _, tableChunk := range tableChunks {
+			chunkPath := filepath.Join(tablePath, tableChunk)
+			chunkData, err := os.ReadFile(chunkPath)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					log.Printf("Error reading table chunk %s for chain %s: %s", chunkPath, chainId, err)
+				}
+				continue
+			}
+			var entries []Entry
+			err = json.Unmarshal(chunkData, &entries)
+			if err != nil {
+				log.Printf("Error unmarshalling table chunk %s for chain %s: %s", chunkPath, chainId, err)
+				continue
+			}
+			for _, entry := range entries {
+				entryId, _, entryBlock := parseEntryFields(entry)
+				table.ObsIds[entryId] = struct{}{}
+
+				if entryBlock > *table.QueryMinBlock {
+					*table.QueryMinBlock = entryBlock
+				}
+			}
+			states[tableName] = table
+		}
+	}
+
+	log.Printf("Loaded meta for chain %s: %v", chainId, meta)
+	return metaPtr, states, err
+}
+
+func parseEntryFields(entry Entry) (entryId string, entryTime time.Time, entryBlock int) {
+	entryId = string(entry["id"])
+	entryTimeStr := string(entry["time"])
+	entryTimeInt, err := strconv.ParseInt(entryTimeStr[1:len(entryTimeStr)-1], 10, 64)
+	if err != nil {
+		log.Printf("Error parsing entry time for %v: %s", entry, err)
+		panic(err)
+	}
+	// log.Println(entryTimeInt)
+	entryTime = time.Unix(entryTimeInt, 0).UTC()
+	entryBlockStr := string(entry["block"])
+	entryBlock, err = strconv.Atoi(entryBlockStr[1 : len(entryBlockStr)-1])
+	if err != nil {
+		log.Printf("Error parsing block number for %v: %s", entry, err)
+		panic(err)
+	}
+	return
+}
+
+func main() {
+	var startupCacheDir = flag.String("startupCacheDir", "", "Directory to load startup cache from")
+	var listenAddr = flag.String("listenAddr", "", "Enable serving cache over HTTP on this address")
+	flag.Parse()
+
+	enabledNetCfgPaths := flag.Args()
+	if *startupCacheDir == "" {
+		log.Fatal("No startup cache directory provided. Use -startupCacheDir to specify the directory.")
+	}
+	if len(enabledNetCfgPaths) == 0 {
+		log.Fatal("No network config paths provided. Supply paths to network config files as arguments.")
+	}
+	log.Println("Got network config paths:", enabledNetCfgPaths)
+
+	if *listenAddr != "" {
+		StartCacheServer(*listenAddr, *startupCacheDir)
+	} else {
+		log.Println("Not starting the HTTP server, running in local mode")
+	}
+
+	chainCfgs := make(map[types.ChainId]loader.ChainConfig)
+	for _, netCfgPath := range enabledNetCfgPaths {
+		netCfg := loader.LoadNetworkConfig(netCfgPath)
+		for _, chainCfg := range netCfg {
+			chainCfgs[types.IntToChainId(chainCfg.ChainID)] = chainCfg
+		}
+	}
+
+	if len(chainCfgs) == 0 {
+		log.Fatal("No chain configurations loaded. Check network config paths.")
+	}
+
+	wg := sync.WaitGroup{}
+	for {
+		for _, chainCfg := range chainCfgs {
+			wg.Add(1)
+			go startupCacher(chainCfg, *startupCacheDir, &wg)
+		}
+		wg.Wait()
+		time.Sleep(CACHE_UPDATE_INTERVAL)
+	}
+}

--- a/cmd/startupCacher/server.go
+++ b/cmd/startupCacher/server.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+func StartCacheServer(listenAddr string, startupCacheDir string) {
+	log.Println("Starting HTTP server at", listenAddr)
+	fs := http.FileServer(http.Dir(startupCacheDir))
+	mux := http.NewServeMux()
+	mux.Handle("/", fs)
+	// List of chunks files for the given chain and table.
+	mux.HandleFunc("/{chain}/{table}/chunks.json", func(w http.ResponseWriter, r *http.Request) {
+		chain := r.PathValue("chain")
+		if chain == "" {
+			http.Error(w, "No chain provided", http.StatusBadRequest)
+			return
+		}
+		table := r.PathValue("table")
+		if table == "" {
+			http.Error(w, "No table provided", http.StatusBadRequest)
+			return
+		}
+		tablePath := filepath.Join(startupCacheDir, chain, table)
+		files, err := os.ReadDir(tablePath)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error reading chain directory: %s", err), http.StatusInternalServerError)
+			return
+		}
+		chunks := []string{}
+		for _, file := range files {
+			if !file.IsDir() && strings.HasPrefix(file.Name(), table+"_") {
+				chunks = append(chunks, file.Name())
+			}
+		}
+		slices.SortFunc(chunks, func(i, j string) int {
+			iBlockStr := strings.Split(strings.Split(i, "_")[1], "-")[0]
+			iBlock, _ := strconv.Atoi(iBlockStr)
+			jBlockStr := strings.Split(strings.Split(j, "_")[1], "-")[0]
+			jBlock, _ := strconv.Atoi(jBlockStr)
+			if iBlock < jBlock {
+				return -1
+			} else if iBlock > jBlock {
+				return 1
+			}
+			return 0
+		})
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(chunks)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error encoding response: %s", err), http.StatusInternalServerError)
+		}
+	})
+
+	// To simplify partially clearing the cache
+	deleteHandler := func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		chain := r.PathValue("chain")
+		if chain == "" {
+			http.Error(w, "No chain provided", http.StatusBadRequest)
+			return
+		}
+		table := r.PathValue("table")
+		afterStr := r.PathValue("after")
+		after := 0
+		if afterStr != "" {
+			after, err = strconv.Atoi(afterStr)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Invalid value for `after`: %s", err), http.StatusBadRequest)
+				return
+			}
+		}
+		log.Println("Deleting entries for", chain, table, "after", after)
+
+		tables := []string{table}
+		if table == "" {
+			tables = tables[:0]
+			tableFiles, err := os.ReadDir(filepath.Join(startupCacheDir, chain))
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Error reading chain directory: %s", err), http.StatusInternalServerError)
+				return
+			}
+			for _, file := range tableFiles {
+				if file.IsDir() {
+					tables = append(tables, file.Name())
+				}
+			}
+		}
+
+		deleted := []string{}
+		for _, table := range tables {
+			tablePath := filepath.Join(startupCacheDir, chain, table)
+			chunks, err := os.ReadDir(tablePath)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Error reading table directory: %s", err), http.StatusInternalServerError)
+				return
+			}
+			for _, chunk := range chunks {
+				if !chunk.IsDir() && strings.HasPrefix(chunk.Name(), table+"_") {
+					chunkBlockStr := strings.Split(strings.Split(chunk.Name(), "_")[1], "-")[0]
+					chunkBlock, err := strconv.Atoi(chunkBlockStr)
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Error parsing block number for %s: %s", chunkBlockStr, err), http.StatusInternalServerError)
+						return
+					}
+
+					if chunkBlock > after {
+						err = os.Remove(filepath.Join(tablePath, chunk.Name()))
+						deleted = append(deleted, chunk.Name())
+						if err != nil {
+							http.Error(w, fmt.Sprintf("Error deleting file: %s", err), http.StatusInternalServerError)
+							return
+						}
+					}
+				}
+			}
+		}
+
+		fmt.Fprintf(w, "Deleted %d entries: %v", len(deleted), deleted)
+	}
+	mux.HandleFunc("/delete/{chain}/{table}/{after}", deleteHandler)
+	mux.HandleFunc("/delete/{chain}/{table}/all", deleteHandler)
+	mux.HandleFunc("/delete/{chain}/all", deleteHandler)
+	go http.ListenAndServe(listenAddr, mux)
+}

--- a/controller/startupCache.go
+++ b/controller/startupCache.go
@@ -1,0 +1,227 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/CrocSwap/graphcache-go/loader"
+	"github.com/CrocSwap/graphcache-go/types"
+)
+
+func LoadStartupCache(startupCacheSource string, syncer SubgraphSyncer) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("Warning: panic during startup cache loading:", r)
+		}
+	}()
+	log.Printf("Loading startup cache from %s", startupCacheSource)
+	cache := NewStartupCacheProvider(startupCacheSource, syncer.ChainId())
+
+	lastBlocks := loader.SubgraphStartBlocks{}
+	lastBlocksMap := map[string]*int{
+		"swaps":            &lastBlocks.Swaps,
+		"aggEvents":        &lastBlocks.Aggs,
+		"liquidityChanges": &lastBlocks.Liq,
+		"knockoutCrosses":  &lastBlocks.Ko,
+		"feeChanges":       &lastBlocks.Fee,
+		"userBalances":     &lastBlocks.Bal,
+	}
+
+	maxBlock := 0 // just for visual output
+	allChunks := make([]string, 0)
+	for tableName := range lastBlocksMap {
+		chunkNames, err := cache.GetChunks(tableName)
+		if err != nil {
+			log.Printf("Warning: failed to get startup cache chunks for %s: %s", tableName, err)
+			return
+		}
+		allChunks = append(allChunks, chunkNames...)
+		for _, chunkName := range chunkNames {
+			blockStr := strings.Split(strings.Split(chunkName, "_")[1], "-")[1]
+			block, _ := strconv.Atoi(blockStr[:len(blockStr)-5])
+			if block > maxBlock {
+				maxBlock = block
+			}
+		}
+	}
+
+	// To prevent slowdown due to sorting when inserting into TX history, we interleave chunks from each table
+	slices.SortFunc(allChunks, func(i, j string) int {
+		iBlockStr := strings.Split(strings.Split(i, "_")[1], "-")[0]
+		iBlock, _ := strconv.Atoi(iBlockStr)
+		jBlockStr := strings.Split(strings.Split(j, "_")[1], "-")[0]
+		jBlock, _ := strconv.Atoi(jBlockStr)
+		if iBlock < jBlock {
+			return -1
+		} else if iBlock > jBlock {
+			return 1
+		}
+		return 0
+	})
+
+	for _, chunkName := range allChunks {
+		tableName := strings.Split(chunkName, "_")[0]
+		log.Printf("Loading startup chunk %s", chunkName)
+		data, err := cache.GetTableChunk(tableName, chunkName)
+		if err != nil {
+			log.Printf("Warning: failed to get chunk %s", chunkName)
+			return
+		}
+
+		if data == nil {
+			log.Printf("Warning: no data for chunk %s", chunkName)
+			return
+		}
+
+		lastObs, _, err := syncer.IngestEntries(tableName, data, *lastBlocksMap[tableName], maxBlock)
+		if err != nil {
+			log.Printf("Warning: failed to ingest startup cache chunk %s for table %s: %s", chunkName, tableName, err)
+			return
+		}
+		*lastBlocksMap[tableName] = lastObs
+
+		syncer.SetStartBlocks(lastBlocks)
+	}
+
+	syncer.SetStartBlocks(lastBlocks)
+	log.Printf("Startup cache loaded. Swap: %d Agg: %d Bal: %d Liq: %d Ko: %d Fee: %d", lastBlocks.Swaps, lastBlocks.Aggs, lastBlocks.Bal, lastBlocks.Liq, lastBlocks.Ko, lastBlocks.Fee)
+}
+
+type startupCacheProvider struct {
+	cacheSource string
+	chainId     types.ChainId
+	isHttp      bool
+}
+
+func NewStartupCacheProvider(cacheSource string, chainId types.ChainId) startupCacheProvider {
+	isHttp := false
+	if strings.HasPrefix(cacheSource, "http") {
+		isHttp = true
+	}
+	return startupCacheProvider{
+		cacheSource: cacheSource,
+		chainId:     chainId,
+		isHttp:      isHttp,
+	}
+}
+
+// If startup loader encounters an error the indexer will have to continue syncing from the
+// last loaded block, which might be slow. Better to retry a few times before giving up.
+const HTTP_MAX_ATTEMPTS = 5
+
+func (p startupCacheProvider) GetChunks(tableName string) (chunks []string, err error) {
+	if p.isHttp {
+		attempts := 0
+		var resp *http.Response
+		for {
+			attempts++
+			if attempts > HTTP_MAX_ATTEMPTS {
+				return nil, err
+			}
+			h := http.Client{Timeout: 10 * time.Second}
+			resp, err = h.Get(fmt.Sprintf("%s/%s/%s/chunks.json", p.cacheSource, p.chainId, tableName))
+			if err != nil {
+				log.Printf("Warning: failed to fetch startup cache days: %s. Attempt %d/%d", err, attempts, HTTP_MAX_ATTEMPTS)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != 200 {
+				log.Printf("Warning: failed to fetch startup cache days, status code: %d. Attempt %d/%d", resp.StatusCode, attempts, HTTP_MAX_ATTEMPTS)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			var data []byte
+			data, err = io.ReadAll(resp.Body)
+			if err != nil {
+				log.Printf("Warning: failed to read startup cache days response: %s. Attempt %d/%d", err, attempts, HTTP_MAX_ATTEMPTS)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			err = json.Unmarshal(data, &chunks)
+			return chunks, err
+		}
+	} else {
+		tablePath := filepath.Join(p.cacheSource, string(p.chainId), tableName)
+		files, err := os.ReadDir(tablePath)
+		if err != nil {
+			log.Println("Warning: failed to read startup cache table directory:", err)
+			return nil, err
+		}
+
+		chunkNames := []string{}
+		for _, file := range files {
+			if !file.IsDir() && strings.HasPrefix(file.Name(), tableName+"_") {
+				chunkNames = append(chunkNames, file.Name())
+			}
+		}
+		slices.SortFunc(chunkNames, func(i, j string) int {
+			iBlockStr := strings.Split(strings.Split(i, "_")[1], "-")[0]
+			iBlock, _ := strconv.Atoi(iBlockStr)
+			jBlockStr := strings.Split(strings.Split(j, "_")[1], "-")[0]
+			jBlock, _ := strconv.Atoi(jBlockStr)
+			if iBlock < jBlock {
+				return -1
+			} else if iBlock > jBlock {
+				return 1
+			}
+			return 0
+		})
+		return chunkNames, nil
+	}
+}
+
+func (p startupCacheProvider) GetTableChunk(tableName string, chunkName string) (data []byte, err error) {
+	if p.isHttp {
+		var resp *http.Response
+		attempts := 0
+		for {
+			attempts++
+			if attempts > HTTP_MAX_ATTEMPTS {
+				return nil, err
+			}
+			// call the http endpoint with /{chainId}/{day}/{table} to get the table data
+			h := http.Client{Timeout: 10 * time.Second}
+			resp, err = h.Get(fmt.Sprintf("%s/%s/%s/%s", p.cacheSource, p.chainId, tableName, chunkName))
+			if err != nil {
+				log.Printf("Warning: failed to fetch startup cache chunk %s for table %s: %s. Attempt %d/%d", chunkName, tableName, err, attempts, HTTP_MAX_ATTEMPTS)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode == 404 {
+				return nil, nil
+			}
+
+			if resp.StatusCode != 200 {
+				log.Printf("Warning: failed to fetch startup cache chunk %s for table %s, status code: %d. Attempt %d/%d", chunkName, tableName, resp.StatusCode, attempts, HTTP_MAX_ATTEMPTS)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			data, err = io.ReadAll(resp.Body)
+			return data, err
+		}
+	} else {
+		tablePath := filepath.Join(p.cacheSource, string(p.chainId), tableName, chunkName)
+		data, err := os.ReadFile(tablePath)
+		if err != nil {
+			log.Println("Warning: failed to read startup cache chunk:", err)
+			return nil, err
+		}
+		return data, nil
+	}
+}

--- a/controller/syncCombined.go
+++ b/controller/syncCombined.go
@@ -1,0 +1,126 @@
+package controller
+
+import (
+	"log"
+	"time"
+
+	"github.com/CrocSwap/graphcache-go/loader"
+	"github.com/CrocSwap/graphcache-go/types"
+)
+
+type CombinedSubgraphSyncer struct {
+	cntr       *ControllerOverNetwork
+	cfg        loader.SyncChannelConfig
+	channels   syncChannels
+	lastBlocks loader.CombinedStartBlocks
+}
+
+func NewCombinedSubgraphSyncer(controller *Controller, chainConfig loader.ChainConfig, network types.NetworkName) *CombinedSubgraphSyncer {
+	start := SubgraphStartBlocks{
+		Bal:   0,
+		Swaps: 0,
+		Aggs:  0,
+	}
+	return NewCombinedSubgraphSyncerAtStart(controller, chainConfig, network, start)
+}
+
+func NewCombinedSubgraphSyncerAtStart(controller *Controller, chainConfig loader.ChainConfig, network types.NetworkName, startBlocks SubgraphStartBlocks) *CombinedSubgraphSyncer {
+	sync := makeCombinedSubgraphSyncer(controller, chainConfig, network)
+	sync.lastBlocks.Bal = startBlocks.Bal
+	sync.lastBlocks.Swap = startBlocks.Swaps
+	sync.lastBlocks.Agg = startBlocks.Aggs
+	sync.syncStart()
+	return &sync
+}
+
+func makeCombinedSubgraphSyncer(controller *Controller, chainConfig loader.ChainConfig, network types.NetworkName) CombinedSubgraphSyncer {
+	cfg := loader.SyncChannelConfig{
+		Chain:   chainConfig,
+		Network: network,
+	}
+	netCntr := controller.OnNetwork(network)
+
+	return CombinedSubgraphSyncer{
+		cntr:     netCntr,
+		cfg:      cfg,
+		channels: makeSyncChannels(netCntr, cfg),
+	}
+}
+
+const COMBINED_SUBGRAPH_POLL_SECS = 3
+
+func (s *CombinedSubgraphSyncer) PollSubgraphUpdates() {
+	s.syncLoop(false)
+}
+
+func (s *CombinedSubgraphSyncer) syncStart() {
+	s.syncLoop(true)
+	log.Printf("Startup subgraph sync done on chainId=%d", s.cntr.chainCfg.ChainID)
+}
+
+const MAX_BLOCK = 999999999
+
+func (s *CombinedSubgraphSyncer) syncLoop(startupSync bool) {
+	lastSyncBlock := 0
+	for {
+		newRows := false
+		syncBlock, comboData, err := loader.CombinedQuery(s.cfg, s.lastBlocks, MAX_BLOCK)
+		if err != nil {
+			log.Println("Warning unable to send combined query:", err.Error())
+			time.Sleep(COMBINED_SUBGRAPH_POLL_SECS * time.Second)
+			continue
+		}
+
+		lastObsSwaps, hasMoreSwaps, errSwaps := s.channels.swaps.IngestEntries(comboData.Swaps, s.lastBlocks.Swap, syncBlock)
+		lastObsAgg, hasMoreAggs, errAggs := s.channels.aggs.IngestEntries(comboData.Aggs, s.lastBlocks.Agg, syncBlock)
+		lastObsBal, hasMoreBals, errBals := s.channels.bal.IngestEntries(comboData.Bals, s.lastBlocks.Bal, syncBlock)
+
+		lastObsLiq, hasMoreLiqs, errLiqs := s.channels.liq.IngestEntries(comboData.Liqs, s.lastBlocks.Liq, syncBlock)
+		lastObsKo, hasMoreKos, errKos := s.channels.ko.IngestEntries(comboData.Kos, s.lastBlocks.Ko, syncBlock)
+		lastObsFees, hasMoreFees, errFees := s.channels.fees.IngestEntries(comboData.Fees, s.lastBlocks.Fee, syncBlock)
+
+		if errSwaps != nil || errAggs != nil || errBals != nil || errLiqs != nil || errKos != nil || errFees != nil {
+			log.Println("Warning unable to ingest entries:", errSwaps, errAggs, errBals, errLiqs, errKos, errFees)
+			time.Sleep(COMBINED_SUBGRAPH_POLL_SECS * time.Second)
+			continue
+		}
+
+		if lastObsSwaps > s.lastBlocks.Swap || lastObsAgg > s.lastBlocks.Agg || lastObsBal > s.lastBlocks.Bal || lastObsLiq > s.lastBlocks.Liq || lastObsKo > s.lastBlocks.Ko || lastObsFees > s.lastBlocks.Fee {
+			newRows = true
+		}
+		if lastObsSwaps > s.lastBlocks.Swap {
+			s.lastBlocks.Swap = lastObsSwaps
+		}
+		if lastObsAgg > s.lastBlocks.Agg {
+			s.lastBlocks.Agg = lastObsAgg
+		}
+		if lastObsBal > s.lastBlocks.Bal {
+			s.lastBlocks.Bal = lastObsBal
+		}
+		if lastObsLiq > s.lastBlocks.Liq {
+			s.lastBlocks.Liq = lastObsLiq
+		}
+		if lastObsKo > s.lastBlocks.Ko {
+			s.lastBlocks.Ko = lastObsKo
+		}
+		if lastObsFees > s.lastBlocks.Fee {
+			s.lastBlocks.Fee = lastObsFees
+		}
+
+		if newRows {
+			log.Printf("Sync step. Swap: %d Agg: %d Bal: %d Liq: %d Ko: %d Fee: %d", s.lastBlocks.Swap, s.lastBlocks.Agg, s.lastBlocks.Bal, s.lastBlocks.Liq, s.lastBlocks.Ko, s.lastBlocks.Fee)
+		}
+
+		// If no more data to backfill, either sleep or exit if it's a startup sync.
+		if !hasMoreSwaps && !hasMoreAggs && !hasMoreBals && !hasMoreLiqs && !hasMoreKos && !hasMoreFees {
+			if startupSync {
+				break
+			}
+			if syncBlock > lastSyncBlock {
+				log.Printf("New subgraph time %d", syncBlock)
+				lastSyncBlock = syncBlock
+			}
+			time.Sleep(COMBINED_SUBGRAPH_POLL_SECS * time.Second)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CrocSwap/graphcache-go
 
-go 1.20
+go 1.22
 
 require (
 	github.com/ethereum/go-ethereum v1.11.6

--- a/loader/subgraph.go
+++ b/loader/subgraph.go
@@ -104,10 +104,10 @@ func queryFromSubgraph(cfg ChainConfig, query SubgraphQuery, startTime int, endT
 	return result, err
 }
 
-func queryFromSubgraphCombined(cfg ChainConfig, query SubgraphQuery, isAsc bool, minBlocks CombinedStartBlocks, maxBlock int) ([]byte, error) {
+func queryFromSubgraphCombined(cfg ChainConfig, query SubgraphQuery, isAsc bool, minBlocks SubgraphStartBlocks, maxBlock int) ([]byte, error) {
 	req := GraphRequest[CombinedGraphReqVars]{
 		Query:     query,
-		Variables: makeCombinedSubgraphVars(isAsc, minBlocks.Swap, maxBlock, minBlocks.Liq, maxBlock, minBlocks.Agg, maxBlock, minBlocks.Bal, maxBlock, minBlocks.Fee, maxBlock, minBlocks.Ko, maxBlock),
+		Variables: makeCombinedSubgraphVars(isAsc, minBlocks.Swaps, maxBlock, minBlocks.Liq, maxBlock, minBlocks.Aggs, maxBlock, minBlocks.Bal, maxBlock, minBlocks.Fee, maxBlock, minBlocks.Ko, maxBlock),
 	}
 	result, err := queryFromSubgraphTry(cfg, req)
 

--- a/loader/syncChannel.go
+++ b/loader/syncChannel.go
@@ -131,8 +131,8 @@ func (s *SyncChannel[R, S]) SyncTableToSubgraph(startBlock int, endBlock int) (i
 		}
 
 		if nIngested > 0 {
-			log.Printf("Loaded %d rows from subgraph from query %s on time=%d-%d",
-				nIngested, s.config.Query, queryStartBlock, queryEndBlock)
+			log.Printf("Loaded %d rows (total %d) from subgraph from query %s on time=%d-%d",
+				nIngested, s.RowsIngested, s.config.Query, queryStartBlock, queryEndBlock)
 		}
 	}
 	return nIngested, nil
@@ -144,6 +144,7 @@ func (s *SyncChannel[R, S]) ingestEntry(r R) (bool, int) {
 	if !hasEntry {
 		s.idsObserved[s.tbl.GetID(r)] = true
 		s.consumeFn(r)
+		s.RowsIngested += 1
 		return true, s.tbl.GetBlock(r)
 	} else {
 		return false, -1

--- a/loader/syncChannelCombined.go
+++ b/loader/syncChannelCombined.go
@@ -1,0 +1,105 @@
+package loader
+
+import (
+	"encoding/json"
+	"log"
+)
+
+type combinedEntry struct {
+	Block struct {
+		Time   int    `json:"timestamp"`
+		Number int    `json:"number"`
+		Hash   string `json:"hash"`
+	} `json:"block"`
+}
+
+type CombinedData struct {
+	Meta  combinedEntry   `json:"_meta"`
+	Swaps json.RawMessage `json:"swaps"`
+	Aggs  json.RawMessage `json:"aggEvents"`
+	Liqs  json.RawMessage `json:"liquidityChanges"`
+	Kos   json.RawMessage `json:"knockoutCrosses"`
+	Fees  json.RawMessage `json:"feeChanges"`
+	Bals  json.RawMessage `json:"userBalances"`
+}
+
+type combinedWrapper struct {
+	Data CombinedData `json:"data"`
+}
+
+type CombinedStartBlocks struct {
+	Swap int
+	Agg  int
+	Bal  int
+	Fee  int
+	Ko   int
+	Liq  int
+}
+
+func CombinedQuery(cfg SyncChannelConfig, minBlocks CombinedStartBlocks, maxBlock int) (metaBlock int, combinedData *CombinedData, err error) {
+	cfg.Query = "./artifacts/graphQueries/combined.query"
+	combinedQuery := readQueryPath(cfg.Query)
+
+	resp, err := queryFromSubgraphCombined(cfg.Chain, combinedQuery, true, minBlocks, maxBlock)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	result, err := parseCombinedResp(resp)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if result.Meta.Block.Number == 0 {
+		log.Println("Warning subgraph latest block number is 0. Retrying ", cfg.Network)
+		return CombinedQuery(cfg, minBlocks, maxBlock)
+	} else {
+		return result.Meta.Block.Number, result, nil
+	}
+}
+
+func parseCombinedResp(body []byte) (*CombinedData, error) {
+	var parsed combinedWrapper
+
+	err := json.Unmarshal(body, &parsed)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed.Data, nil
+}
+
+func (s *SyncChannel[R, S]) IngestEntries(data []byte, queryStartBlock, queryEndBlock int) (lastObs int, hasMore bool, err error) {
+	nIngested := 0
+	lastObs = queryStartBlock
+
+	entries, err := s.tbl.ParseSubGraphRespUnwrapped(data)
+	if err != nil {
+		log.Println("Warning subgraph data decode error: " + err.Error())
+		return 0, true, err
+	}
+
+	if len(entries) == 0 {
+		log.Printf("Warning subgraph data for %s returned no entries while the last seen row was expected", s.config.Query)
+		return 0, true, nil
+	}
+
+	for _, entry := range entries {
+		row := s.tbl.ConvertSubGraphRow(entry, string(s.config.Network))
+		isFreshPoint, eventBlock := s.ingestEntry(row)
+
+		if isFreshPoint {
+			nIngested += 1
+		}
+		if eventBlock > lastObs {
+			lastObs = eventBlock
+		}
+	}
+
+	if nIngested > 0 {
+		log.Printf("Loaded %d rows (total %d) from subgraph from query %s on block=%d-%d",
+			nIngested, s.RowsIngested, s.config.Query, queryStartBlock, queryEndBlock)
+	}
+	hasMore = nIngested > 0 || len(entries) == 1000
+	// log.Println("Ingested", nIngested, "rows, len", len(entries), "hasMore", hasMore, s.config.Query)
+	return lastObs, hasMore, nil
+}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		syncs = append(syncs, syncer)
 	}
 
-	cntrl.SpinUntilLiqSync()
+	// cntrl.SpinUntilLiqSync()
 	for _, syncer := range syncs {
 		go syncer.PollSubgraphUpdates()
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	var balStart = flag.Int("balStart", 0, "Block number to start user balance processing")
 	var extendedApi = flag.Bool("extendedApi", false, "Expose additional methods in the API")
 	var combinedQuery = flag.Bool("combinedQuery", false, "Use the combined subgraph query instead of individual ones")
+	var startupCache = flag.String("startupCache", "", "Either directory or HTTP URL to load startup cache from")
 
 	flag.Parse()
 
@@ -37,16 +38,16 @@ func main() {
 	syncs := make([]controller.SubgraphSyncer, 0)
 
 	for network, chainCfg := range netCfg {
-		startBlocks := controller.SubgraphStartBlocks{
+		startBlocks := loader.SubgraphStartBlocks{
 			Swaps: *swapStart,
 			Aggs:  *aggStart,
 			Bal:   *balStart,
 		}
 		var syncer controller.SubgraphSyncer
 		if *combinedQuery {
-			syncer = controller.NewCombinedSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks)
+			syncer = controller.NewCombinedSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks, *startupCache)
 		} else {
-			syncer = controller.NewSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks)
+			syncer = controller.NewSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks, *startupCache)
 		}
 		syncs = append(syncs, syncer)
 	}

--- a/main.go
+++ b/main.go
@@ -13,11 +13,13 @@ import (
 func main() {
 	var netCfgPath = flag.String("netCfg", "./config/ethereum.json", "network config file")
 	var apiPath = flag.String("apiPath", "gcgo", "API server root path")
+	var listenAddr = flag.String("listenAddr", ":8080", "HTTP server listen address")
 	var noRpcMode = flag.Bool("noRpcMode", false, "Run in mode with no RPC calls")
 	var swapStart = flag.Int("swapStart", 0, "Block number to start swap event processing")
 	var aggStart = flag.Int("aggStart", 0, "Block number to start aggregate event processing")
 	var balStart = flag.Int("balStart", 0, "Block number to start user balance processing")
 	var extendedApi = flag.Bool("extendedApi", false, "Expose additional methods in the API")
+	var combinedQuery = flag.Bool("combinedQuery", false, "Use the combined subgraph query instead of individual ones")
 
 	flag.Parse()
 
@@ -32,7 +34,7 @@ func main() {
 		cntrl = controller.NewOnQuery(netCfg, cache, &nonQuery)
 	}
 
-	syncs := make([]*controller.SubgraphSyncer, 0)
+	syncs := make([]controller.SubgraphSyncer, 0)
 
 	for network, chainCfg := range netCfg {
 		startBlocks := controller.SubgraphStartBlocks{
@@ -40,7 +42,12 @@ func main() {
 			Aggs:  *aggStart,
 			Bal:   *balStart,
 		}
-		syncer := controller.NewSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks)
+		var syncer controller.SubgraphSyncer
+		if *combinedQuery {
+			syncer = controller.NewCombinedSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks)
+		} else {
+			syncer = controller.NewSubgraphSyncerAtStart(cntrl, chainCfg, network, startBlocks)
+		}
 		syncs = append(syncs, syncer)
 	}
 
@@ -51,5 +58,5 @@ func main() {
 
 	views := views.Views{Cache: cache, OnChain: onChain}
 	apiServer := server.APIWebServer{Views: &views}
-	apiServer.Serve(*apiPath, *extendedApi)
+	apiServer.Serve(*apiPath, *listenAddr, *extendedApi)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -15,7 +15,7 @@ type APIWebServer struct {
 	Views views.IViews
 }
 
-func (s *APIWebServer) Serve(prefix string, extendedApi bool) {
+func (s *APIWebServer) Serve(prefix string, listenAddr string, extendedApi bool) {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 	r.Use(CORSMiddleware())
@@ -46,7 +46,7 @@ func (s *APIWebServer) Serve(prefix string, extendedApi bool) {
 	}
 
 	log.Println("API Serving at", prefix)
-	r.Run()
+	r.Run(listenAddr)
 }
 
 func (s *APIWebServer) queryUserTokens(c *gin.Context) {

--- a/tables/aggEvents.go
+++ b/tables/aggEvents.go
@@ -126,4 +126,19 @@ func (tbl AggEventsTable) ParseSubGraphResp(body []byte) ([]AggEventSubGraph, er
 	return ret, nil
 }
 
+func (tbl AggEventsTable) ParseSubGraphRespUnwrapped(body []byte) ([]AggEventSubGraph, error) {
+	var parsed AggEventSubGraphData
+
+	err := json.Unmarshal(body, &parsed.AggEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]AggEventSubGraph, 0)
+	for _, entry := range parsed.AggEvents {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}
+
 func (tbl AggEventsTable) SqlTableName() string { return "aggevents" }

--- a/tables/balances.go
+++ b/tables/balances.go
@@ -92,3 +92,18 @@ func (tbl BalanceTable) ParseSubGraphResp(body []byte) ([]BalanceSubGraph, error
 	}
 	return ret, nil
 }
+
+func (tbl BalanceTable) ParseSubGraphRespUnwrapped(body []byte) ([]BalanceSubGraph, error) {
+	var parsed BalanceSubGrapData
+
+	err := json.Unmarshal(body, &parsed.UserBalances)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]BalanceSubGraph, 0)
+	for _, entry := range parsed.UserBalances {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}

--- a/tables/feechanges.go
+++ b/tables/feechanges.go
@@ -117,3 +117,18 @@ func (tbl FeeTable) ParseSubGraphResp(body []byte) ([]FeeChangeSubGraph, error) 
 	}
 	return ret, nil
 }
+
+func (tbl FeeTable) ParseSubGraphRespUnwrapped(body []byte) ([]FeeChangeSubGraph, error) {
+	var parsed FeeChangeSubGraphData
+
+	err := json.Unmarshal(body, &parsed.FeeChanges)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]FeeChangeSubGraph, 0)
+	for _, entry := range parsed.FeeChanges {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}

--- a/tables/interface.go
+++ b/tables/interface.go
@@ -14,6 +14,7 @@ type ITable[Row any, SubGraphRow any] interface {
 	ConvertSubGraphRow(SubGraphRow, string) Row
 	SqlTableName() string
 	ParseSubGraphResp(body []byte) ([]SubGraphRow, error)
+	ParseSubGraphRespUnwrapped(body []byte) ([]SubGraphRow, error)
 }
 
 func parseNullableInt(s string) *int {

--- a/tables/knockouts.go
+++ b/tables/knockouts.go
@@ -125,3 +125,18 @@ func (tbl KnockoutTable) ParseSubGraphResp(body []byte) ([]KnockoutCrossSubGraph
 	}
 	return ret, nil
 }
+
+func (tbl KnockoutTable) ParseSubGraphRespUnwrapped(body []byte) ([]KnockoutCrossSubGraph, error) {
+	var parsed KnockoutCrossSubGraphData
+
+	err := json.Unmarshal(body, &parsed.KnockoutCrosses)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]KnockoutCrossSubGraph, 0)
+	for _, entry := range parsed.KnockoutCrosses {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}

--- a/tables/liqchanges.go
+++ b/tables/liqchanges.go
@@ -159,3 +159,18 @@ func (tbl LiqChangeTable) ParseSubGraphResp(body []byte) ([]LiqChangeSubGraph, e
 	}
 	return ret, nil
 }
+
+func (tbl LiqChangeTable) ParseSubGraphRespUnwrapped(body []byte) ([]LiqChangeSubGraph, error) {
+	var parsed LiqChangeSubGraphData
+
+	err := json.Unmarshal(body, &parsed.LiqChanges)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]LiqChangeSubGraph, 0)
+	for _, entry := range parsed.LiqChanges {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}

--- a/tables/swaps.go
+++ b/tables/swaps.go
@@ -148,3 +148,18 @@ func (tbl SwapsTable) ParseSubGraphResp(body []byte) ([]SwapSubGraph, error) {
 	}
 	return ret, nil
 }
+
+func (tbl SwapsTable) ParseSubGraphRespUnwrapped(body []byte) ([]SwapSubGraph, error) {
+	var parsed SwapSubGraphData
+
+	err := json.Unmarshal(body, &parsed.Swaps)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]SwapSubGraph, 0)
+	for _, entry := range parsed.Swaps {
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}


### PR DESCRIPTION
To reduce the number of subgraph queries sent, this PR introduces an optional `CombinedSubgraphSyncer` which queries all tables at once. This helps with the startup sync, but this on its own doesn't reduce the total query count by much - the normal syncer spends most of the queries on polling the meta table during post-backfill runtime. While the combined syncer doesn't eliminate the need for polling (there might not be a way to do that at all), it optimizes it by including the meta query with all others, removing the need to query tables after a routine meta query.

Also, since the frontend doesn't rely on the indexer to fill the transaction history after a user's pending transaction confirms onchain, there's no need to poll the subgraph very often, so this PR increases the poll interval to 3s from 1s. The impact on the feeling of responsiveness of the frontend will be minimal.

EDIT: Unfortunately combined queries are considerably slower during startup sync (which was already very slow). This PR also introduces an optional startup cache. It will run as a separate service which graphcache instances will use to quickly ingest historic state.