### PR TITLE
Improve liquidity refresher and knockout tracking

### DIFF
--- a/cache/memCache.go
+++ b/cache/memCache.go
@@ -20,7 +20,8 @@ type MemoryCache struct {
 	poolKnockouts        RWLockMapMap[types.PoolLocation, types.PositionLocation, *model.KnockoutSubplot]
 	userAndPoolKnockouts RWLockMapMap[chainUserAndPool, types.PositionLocation, *model.KnockoutSubplot]
 
-	knockoutSagas RWLockMap[types.BookLocation, *model.KnockoutSaga]
+	knockoutSagas      RWLockMap[types.BookLocation, *model.KnockoutSaga]
+	knockoutPivotTimes RWLockMap[types.BookLocation, int]
 
 	userTxs        RWLockMapArray[chainAndAddr, types.PoolTxEvent]
 	poolTxs        RWLockMapArray[types.PoolLocation, types.PoolTxEvent]
@@ -47,7 +48,8 @@ func New() *MemoryCache {
 		poolKnockouts:        newRwLockMapMap[types.PoolLocation, types.PositionLocation, *model.KnockoutSubplot](),
 		userAndPoolKnockouts: newRwLockMapMap[chainUserAndPool, types.PositionLocation, *model.KnockoutSubplot](),
 
-		knockoutSagas: newRwLockMap[types.BookLocation, *model.KnockoutSaga](),
+		knockoutSagas:      newRwLockMap[types.BookLocation, *model.KnockoutSaga](),
+		knockoutPivotTimes: newRwLockMap[types.BookLocation, int](),
 
 		userTxs:        newRwLockMapArray[chainAndAddr, types.PoolTxEvent](),
 		poolTxs:        newRwLockMapArray[types.PoolLocation, types.PoolTxEvent](),

--- a/cache/transactors.go
+++ b/cache/transactors.go
@@ -293,7 +293,7 @@ func (m *MemoryCache) MaterializePosition(loc types.PositionLocation) *model.Pos
 	return val
 }
 
-func (m *MemoryCache) MaterializeKnockoutBook(loc types.BookLocation) *model.KnockoutSaga {
+func (m *MemoryCache) MaterializeKnockoutSaga(loc types.BookLocation) *model.KnockoutSaga {
 	val, ok := m.knockoutSagas.lookup(loc)
 	if !ok {
 		val = model.NewKnockoutSaga()
@@ -305,7 +305,7 @@ func (m *MemoryCache) MaterializeKnockoutBook(loc types.BookLocation) *model.Kno
 func (m *MemoryCache) MaterializeKnockoutPos(loc types.PositionLocation) *model.KnockoutSubplot {
 	val, ok := m.liqKnockouts.lookup(loc)
 	if !ok {
-		saga := m.MaterializeKnockoutBook(loc.ToBookLoc())
+		saga := m.MaterializeKnockoutSaga(loc.ToBookLoc())
 		val = saga.ForUser(loc.User)
 		m.liqKnockouts.insert(loc, val)
 		m.userKnockouts.insert(chainAndAddr{loc.ChainId, loc.User}, loc, val)
@@ -316,4 +316,17 @@ func (m *MemoryCache) MaterializeKnockoutPos(loc types.PositionLocation) *model.
 
 	m.poolKoUpdates.insert(loc.PoolLocation, koAndLocPair{loc, val})
 	return val
+}
+
+func (m *MemoryCache) RetrievePivotTime(loc types.BookLocation) int {
+	pos, okay := m.knockoutPivotTimes.lookup(loc)
+	if okay {
+		return pos
+	} else {
+		return 0
+	}
+}
+
+func (m *MemoryCache) SetPivotTime(loc types.BookLocation, pivotTime int) {
+	m.knockoutPivotTimes.insert(loc, pivotTime)
 }

--- a/controller/handles.go
+++ b/controller/handles.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"log"
 	"math/big"
+	"time"
 
 	"github.com/CrocSwap/graphcache-go/loader"
 	"github.com/CrocSwap/graphcache-go/model"
@@ -10,6 +11,9 @@ import (
 )
 
 type IRefreshHandle interface {
+	Hash() [32]byte
+	RefreshTime() int64
+	Skippable() bool
 	RefreshQuery(query *loader.ICrocQuery)
 	LabelTag() string
 }
@@ -66,21 +70,22 @@ func (p *KnockoutAliveHandle) RefreshQuery(query *loader.ICrocQuery) {
 	pivotTime := int(tryQueryAttempt(pivotTimeFn, "pivotTimeLatest"))
 
 	if pivotTime == 0 {
-		p.pos.Liq.UpdateActiveLiq(*big.NewInt(0))
+		p.pos.Liq.UpdateActiveLiq(*big.NewInt(0), time.Now().Unix())
 
 	} else {
 		claimLoc := types.KOClaimLocation{PositionLocation: p.location, PivotTime: pivotTime}
-		liqFn := func() (*big.Int, error) { return (*query).QueryKnockoutLiq(claimLoc) }
-
-		knockoutLiq := tryQueryAttempt(liqFn, "knockoutLiq")
-		p.pos.Liq.UpdateActiveLiq(*knockoutLiq)
+		liqFn := func() (loader.KnockoutLiqResp, error) { return (*query).QueryKnockoutLiq(claimLoc) }
+		koLiqResp := tryQueryAttempt(liqFn, "knockoutLiq")
+		p.pos.Liq.UpdateActiveLiq(*koLiqResp.Liq, time.Now().Unix())
 	}
 }
 
 func (p *KnockoutPostHandle) RefreshQuery(query *loader.ICrocQuery) {
-	liqFn := func() (*big.Int, error) { return (*query).QueryKnockoutLiq(p.location) }
-	knockoutLiq := tryQueryAttempt(liqFn, "knockoutLiq")
-	p.pos.Liq.UpdatePostKOLiq(p.location.PivotTime, *knockoutLiq)
+	liqFn := func() (loader.KnockoutLiqResp, error) { return (*query).QueryKnockoutLiq(p.location) }
+	koLiqResp := tryQueryAttempt(liqFn, "knockoutLiq")
+	if koLiqResp.KnockedOut {
+		p.pos.Liq.UpdatePostKOLiq(p.location.PivotTime, *koLiqResp.Liq, time.Now().Unix())
+	}
 }
 
 func tryQueryAttempt[T any](queryFn func() (T, error), label string) T {
@@ -109,4 +114,52 @@ func (p *KnockoutAliveHandle) LabelTag() string {
 
 func (p *KnockoutPostHandle) LabelTag() string {
 	return "knockoutPost"
+}
+
+func (p *PositionRefreshHandle) RefreshTime() int64 {
+	return p.pos.RefreshTime
+}
+
+func (p *RewardsRefreshHandle) RefreshTime() int64 {
+	return p.pos.RefreshTime
+}
+
+func (p *KnockoutAliveHandle) RefreshTime() int64 {
+	return p.pos.Liq.Active.RefreshTime
+}
+
+func (p *KnockoutPostHandle) RefreshTime() int64 {
+	return p.pos.Liq.Active.RefreshTime
+}
+
+func (p *PositionRefreshHandle) Hash() [32]byte {
+	return p.location.Hash()
+}
+
+func (p *RewardsRefreshHandle) Hash() [32]byte {
+	return p.location.Hash()
+}
+
+func (p *KnockoutAliveHandle) Hash() [32]byte {
+	return p.location.Hash()
+}
+
+func (p *KnockoutPostHandle) Hash() [32]byte {
+	return p.location.Hash()
+}
+
+func (p *PositionRefreshHandle) Skippable() bool {
+	return false
+}
+
+func (p *RewardsRefreshHandle) Skippable() bool {
+	return true
+}
+
+func (p *KnockoutAliveHandle) Skippable() bool {
+	return false
+}
+
+func (p *KnockoutPostHandle) Skippable() bool {
+	return false
 }

--- a/controller/startupCache.go
+++ b/controller/startupCache.go
@@ -31,7 +31,6 @@ func LoadStartupCache(startupCacheSource string, syncer SubgraphSyncer) {
 		"swaps":            &lastBlocks.Swaps,
 		"aggEvents":        &lastBlocks.Aggs,
 		"liquidityChanges": &lastBlocks.Liq,
-		"knockoutCrosses":  &lastBlocks.Ko,
 		"feeChanges":       &lastBlocks.Fee,
 		"userBalances":     &lastBlocks.Bal,
 	}

--- a/controller/workers.go
+++ b/controller/workers.go
@@ -54,7 +54,6 @@ func (msg *koPosUpdateMsg) processUpdate(lr *LiquidityRefresher) {
 	cands, isPossiblyLive := (msg.pos).UpdateLiqChange(msg.liq)
 
 	handle := KnockoutAliveHandle{location: msg.loc, pos: msg.pos}
-	// lr.PushRefresh(&handle, msg.liq.Time)
 
 	if isPossiblyLive {
 		lr.PushRefresh(&handle, msg.liq.Time)
@@ -73,7 +72,8 @@ func (msg *koCrossUpdateMsg) processUpdate(lr *LiquidityRefresher) {
 	for _, cand := range cands {
 		claimLoc := msg.loc.ToClaimLoc(cand.User, cand.PivotTime)
 		subPos := msg.pos.ForUser(cand.User)
-		subPos.Liq.UpdatePostKOLiq(cand.PivotTime, *big.NewInt(0).Set(&subPos.Liq.Active.ConcLiq), 0)
+		activeLiq := subPos.Liq.GetActiveLiq()
+		subPos.Liq.UpdatePostKOLiq(cand.PivotTime, *activeLiq, 0)
 		subPos.Liq.UpdateActiveLiq(*big.NewInt(0), 0)
 		handle := KnockoutPostHandle{location: claimLoc, pos: subPos}
 		lr.PushRefresh(&handle, msg.cross.Time)

--- a/controller/workers.go
+++ b/controller/workers.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"sync"
+	"math/big"
 
 	"github.com/CrocSwap/graphcache-go/loader"
 	"github.com/CrocSwap/graphcache-go/model"
@@ -23,114 +23,60 @@ func initWorkers(_ loader.NetworkConfig, query *loader.ICrocQuery) (*workers, *L
 	}, liqRefresher
 }
 
-type RefreshAccumulator struct {
-	posRefreshers    map[types.PositionLocation]*HandleRefresher
-	koLiveRefreshers map[types.PositionLocation]*HandleRefresher
-	koPostRefreshers map[types.KOClaimLocation]*HandleRefresher
-	lock             sync.Mutex
-}
-
-func watchUpdateSeq(liq *LiquidityRefresher) chan IMsgType {
-	sink := make(chan IMsgType, UPDATE_CHANNEL_SIZE)
-
-	accum := &RefreshAccumulator{
-		posRefreshers:    make(map[types.PositionLocation]*HandleRefresher),
-		koLiveRefreshers: make(map[types.PositionLocation]*HandleRefresher),
-		koPostRefreshers: make(map[types.KOClaimLocation]*HandleRefresher),
-	}
+func watchUpdateSeq(liqRefresher *LiquidityRefresher) chan IMsgType {
+	sink := make(chan IMsgType, 10000) // doesn't really need to be buffered because it gets sent to another buffer anyway
 
 	go func() {
 		for {
 			msg := <-sink
-			msg.processUpdate(accum, liq)
+			msg.processUpdate(liqRefresher)
 		}
 	}()
 	return sink
 }
 
-const UPDATE_CHANNEL_SIZE = 250000
-
 type IMsgType interface {
-	processUpdate(*RefreshAccumulator, *LiquidityRefresher)
+	processUpdate(*LiquidityRefresher)
 }
 
-func (msg *posUpdateMsg) processUpdate(accum *RefreshAccumulator, liq *LiquidityRefresher) {
+func (msg *posUpdateMsg) processUpdate(lr *LiquidityRefresher) {
 	(msg.pos).UpdatePosition(msg.liq)
-
-	accum.lock.Lock()
-	refresher, ok := accum.posRefreshers[msg.loc]
-	if !ok {
-		handle := PositionRefreshHandle{location: msg.loc, pos: msg.pos}
-		refresher = NewHandleRefresher(&handle, liq.pending)
-		accum.posRefreshers[msg.loc] = refresher
-	}
-	accum.lock.Unlock()
-
-	refresher.PushRefresh(msg.liq.Time)
+	handle := PositionRefreshHandle{location: msg.loc, pos: msg.pos}
+	lr.PushRefresh(&handle, msg.liq.Time)
 }
 
-func (msg *posImpactMsg) processUpdate(accum *RefreshAccumulator, liq *LiquidityRefresher) {
-	accum.lock.Lock()
-	refresher, ok := accum.posRefreshers[msg.loc]
-	if !ok {
-		handle := RewardsRefreshHandle{location: msg.loc, pos: msg.pos}
-		refresher = NewHandleRefresher(&handle, liq.pending)
-		accum.posRefreshers[msg.loc] = refresher
-	}
-	accum.lock.Unlock()
-
-	refresher.PushRefreshPoll(msg.eventTime)
+func (msg *posImpactMsg) processUpdate(lr *LiquidityRefresher) {
+	handle := RewardsRefreshHandle{location: msg.loc, pos: msg.pos}
+	lr.PushRefreshPoll(&handle)
 }
 
-func (msg *koPosUpdateMsg) processUpdate(accum *RefreshAccumulator, liq *LiquidityRefresher) {
+func (msg *koPosUpdateMsg) processUpdate(lr *LiquidityRefresher) {
 	cands, isPossiblyLive := (msg.pos).UpdateLiqChange(msg.liq)
 
-	accum.lock.Lock()
-	refresher, ok := accum.koLiveRefreshers[msg.loc]
-	if !ok {
-		handle := KnockoutAliveHandle{location: msg.loc, pos: msg.pos}
-		refresher = NewHandleRefresher(&handle, liq.pending)
-		accum.koLiveRefreshers[msg.loc] = refresher
-	}
-	accum.lock.Unlock()
+	handle := KnockoutAliveHandle{location: msg.loc, pos: msg.pos}
+	// lr.PushRefresh(&handle, msg.liq.Time)
 
 	if isPossiblyLive {
-		refresher.PushRefresh(msg.liq.Time)
+		lr.PushRefresh(&handle, msg.liq.Time)
 	}
 
 	for _, cand := range cands {
-		accum.lock.Lock()
 		claimLoc := types.KOClaimLocation{PositionLocation: msg.loc, PivotTime: cand.PivotTime}
-		refresher, ok := accum.koPostRefreshers[claimLoc]
-
-		if !ok {
-			handle := KnockoutPostHandle{location: claimLoc, pos: msg.pos}
-			refresher = NewHandleRefresher(&handle, liq.pending)
-			accum.koPostRefreshers[claimLoc] = refresher
-		}
-		accum.lock.Unlock()
-
-		refresher.PushRefresh(msg.liq.Time)
+		handle := KnockoutPostHandle{location: claimLoc, pos: msg.pos}
+		lr.PushRefresh(&handle, msg.liq.Time)
 	}
 }
 
-func (msg *koCrossUpdateMsg) processUpdate(accum *RefreshAccumulator, liq *LiquidityRefresher) {
+func (msg *koCrossUpdateMsg) processUpdate(lr *LiquidityRefresher) {
 	cands := (msg.pos).UpdateCross(msg.cross)
 
 	for _, cand := range cands {
-		accum.lock.Lock()
 		claimLoc := msg.loc.ToClaimLoc(cand.User, cand.PivotTime)
-		refresher, ok := accum.koPostRefreshers[claimLoc]
-
-		if !ok {
-			subPos := msg.pos.ForUser(cand.User)
-			handle := KnockoutPostHandle{location: claimLoc, pos: subPos}
-			refresher = NewHandleRefresher(&handle, liq.pending)
-			accum.koPostRefreshers[claimLoc] = refresher
-		}
-		accum.lock.Unlock()
-
-		refresher.PushRefresh(msg.cross.Time)
+		subPos := msg.pos.ForUser(cand.User)
+		subPos.Liq.UpdatePostKOLiq(cand.PivotTime, *big.NewInt(0).Set(&subPos.Liq.Active.ConcLiq), 0)
+		subPos.Liq.UpdateActiveLiq(*big.NewInt(0), 0)
+		handle := KnockoutPostHandle{location: claimLoc, pos: subPos}
+		lr.PushRefresh(&handle, msg.cross.Time)
 	}
 }
 
@@ -155,5 +101,5 @@ type koPosUpdateMsg struct {
 type koCrossUpdateMsg struct {
 	loc   types.BookLocation
 	pos   *model.KnockoutSaga
-	cross tables.KnockoutCross
+	cross tables.LiqChange
 }

--- a/loader/syncChannelCombined.go
+++ b/loader/syncChannelCombined.go
@@ -83,7 +83,7 @@ func (s *SyncChannel[R, S]) IngestEntries(data []byte, queryStartBlock, queryEnd
 	}
 
 	if len(entries) == 0 {
-		log.Printf("Warning subgraph data for %s returned no entries while the last seen row was expected", s.config.Query)
+		log.Printf("Warning subgraph data for %s at %d-%d returned no rows, last seen row was expected", s.config.Query, queryStartBlock, queryEndBlock)
 		// Returning `true` here doesn't change anything during startup sync,
 		// but returning `false` could potentially cause the sync to exit early.
 		// Returning `true` during normal runtime would cause the subgraph to

--- a/model/knockout.go
+++ b/model/knockout.go
@@ -3,17 +3,18 @@ package model
 import (
 	"log"
 	"math/big"
+	"slices"
 
 	"github.com/CrocSwap/graphcache-go/tables"
 	"github.com/CrocSwap/graphcache-go/types"
 )
 
 type KnockoutSubplot struct {
-	mints      []KnockoutSagaTx
-	burns      []KnockoutSagaTx
-	saga       *KnockoutSaga
-	Liq        KnockoutLiquiditySeries
-	LatestTime int
+	Mints            []KnockoutSagaTx
+	Burns            []KnockoutSagaTx
+	saga             *KnockoutSaga
+	Liq              KnockoutLiquiditySeries
+	LatestUpdateTime int
 }
 
 type KnockoutLiquiditySeries struct {
@@ -28,8 +29,9 @@ type KnockoutSaga struct {
 }
 
 type KnockoutSagaTx struct {
-	TxTime int
-	TxHash string
+	TxTime    int
+	TxHash    string
+	PivotTime int
 }
 
 type KnockoutSagaCross struct {
@@ -70,8 +72,8 @@ func (k *KnockoutSaga) ForUser(user types.EthAddress) *KnockoutSubplot {
 			KnockedOut: make(map[int]*PositionLiquidity, 0),
 		}
 		subplot = &KnockoutSubplot{
-			mints: make([]KnockoutSagaTx, 0),
-			burns: make([]KnockoutSagaTx, 0),
+			Mints: make([]KnockoutSagaTx, 0),
+			Burns: make([]KnockoutSagaTx, 0),
 			saga:  k,
 			Liq:   liq,
 		}
@@ -81,13 +83,8 @@ func (k *KnockoutSaga) ForUser(user types.EthAddress) *KnockoutSubplot {
 }
 
 func (k *KnockoutSubplot) UpdateLiqChange(l tables.LiqChange) ([]KnockoutPivotCands, bool) {
-	event := KnockoutSagaTx{
-		TxTime: l.Time,
-		TxHash: l.TX,
-	}
-
-	if l.Time > k.LatestTime {
-		k.LatestTime = l.Time
+	if l.Time > k.LatestUpdateTime {
+		k.LatestUpdateTime = l.Time
 	}
 
 	// By definition, only mint can occur first, so no need to check to see if chnage is a mint
@@ -95,12 +92,10 @@ func (k *KnockoutSubplot) UpdateLiqChange(l tables.LiqChange) ([]KnockoutPivotCa
 		k.Liq.TimeFirstMint = l.Time
 	}
 
-	if l.ChangeType == "mint" {
-		k.mints = append(k.mints, event)
+	if l.ChangeType == tables.ChangeTypeMint {
 		return k.scrapePivotsCandsOnMint(l.Time, types.RequireEthAddr(l.User)), true
 
-	} else if l.ChangeType == "burn" {
-		k.burns = append(k.burns, event)
+	} else if l.ChangeType == tables.ChangeTypeBurn {
 		return make([]KnockoutPivotCands, 0), true
 
 	} else if l.PivotTime != nil && *l.PivotTime > 0 {
@@ -116,19 +111,19 @@ func (k *KnockoutSubplot) UpdateLiqChange(l tables.LiqChange) ([]KnockoutPivotCa
 	}
 }
 
-func (k *KnockoutSaga) UpdateCross(l tables.KnockoutCross) []KnockoutPivotCands {
+func (k *KnockoutSaga) UpdateCross(l tables.LiqChange) []KnockoutPivotCands {
 	event := KnockoutSagaCross{
 		CrossTime: l.Time,
-		PivotTime: l.PivotTime,
+		PivotTime: *l.PivotTime,
 	}
 	k.crosses = append(k.crosses, event)
-	return k.scrapePivotsCandsOnCross(l.PivotTime, l.Time)
+	return k.scrapePivotsCandsOnCross(*l.PivotTime, l.Time)
 }
 
 func (k *KnockoutSubplot) scrapePivotsCandsOnMint(mintTime int, user types.EthAddress) []KnockoutPivotCands {
 	cands := make([]KnockoutPivotCands, 0)
 	for _, cross := range (*k.saga).crosses {
-		if isMintMaybeInPiovt(mintTime, cross.PivotTime, cross.CrossTime) {
+		if isMintMaybeInPivot(mintTime, cross.PivotTime, cross.CrossTime) {
 			cands = append(cands, KnockoutPivotCands{
 				PivotTime: cross.PivotTime,
 				User:      user,
@@ -141,12 +136,14 @@ func (k *KnockoutSubplot) scrapePivotsCandsOnMint(mintTime int, user types.EthAd
 func (k *KnockoutSaga) scrapePivotsCandsOnCross(pivotTime int, crossTime int) []KnockoutPivotCands {
 	cands := make([]KnockoutPivotCands, 0)
 	for userAddr, subplot := range k.users {
-		for _, mint := range subplot.mints {
-			if isMintMaybeInPiovt(mint.TxTime, pivotTime, crossTime) {
-				cands = append(cands, KnockoutPivotCands{
-					PivotTime: pivotTime,
-					User:      userAddr,
-				})
+		for _, mint := range subplot.Mints {
+			cand := KnockoutPivotCands{
+				PivotTime: pivotTime,
+				User:      userAddr,
+			}
+			// Checking if cands already contains cand to not double knock out orders with multiple mints
+			if (mint.PivotTime == pivotTime || isMintMaybeInPivot(mint.PivotTime, pivotTime, crossTime) || isMintMaybeInPivot(mint.TxTime, pivotTime, crossTime)) && !slices.Contains(cands, cand) {
+				cands = append(cands, cand)
 			}
 		}
 	}
@@ -155,19 +152,21 @@ func (k *KnockoutSaga) scrapePivotsCandsOnCross(pivotTime int, crossTime int) []
 
 /* Returns true if there's a possibility that the minted liquidity may be knocked out on the
  * the pivot cross event. */
-func isMintMaybeInPiovt(mintTime int, pivotTime int, knockoutTime int) bool {
+func isMintMaybeInPivot(mintTime int, pivotTime int, knockoutTime int) bool {
 	return mintTime >= pivotTime && mintTime <= knockoutTime
 }
 
-func (k *KnockoutLiquiditySeries) UpdateActiveLiq(liqQty big.Int) {
+func (k *KnockoutLiquiditySeries) UpdateActiveLiq(liqQty big.Int, refreshTime int64) {
 	k.Active.ConcLiq = liqQty
+	k.Active.RefreshTime = refreshTime
 }
 
-func (k *KnockoutLiquiditySeries) UpdatePostKOLiq(pivotTime int, liqQty big.Int) {
-	posLiq, ok := k.KnockedOut[pivotTime]
+func (k *KnockoutLiquiditySeries) UpdatePostKOLiq(pivotTime int, liqQty big.Int, refreshTime int64) {
+	posKoLiq, ok := k.KnockedOut[pivotTime]
 	if !ok {
-		posLiq = &PositionLiquidity{}
-		k.KnockedOut[pivotTime] = posLiq
+		posKoLiq = &PositionLiquidity{}
+		k.KnockedOut[pivotTime] = posKoLiq
 	}
-	posLiq.ConcLiq = liqQty
+	posKoLiq.ConcLiq = liqQty
+	k.Active.RefreshTime = refreshTime
 }

--- a/model/liquidityCurve.go
+++ b/model/liquidityCurve.go
@@ -29,15 +29,15 @@ func NewLiquidityCurve() *LiquidityCurve {
 }
 
 func (c *LiquidityCurve) UpdateLiqChange(l tables.LiqChange) {
-	if l.PositionType == "ambient" {
+	if l.PositionType == tables.PosTypeAmbient {
 		c.AmbientLiq += determineLiquidityMagn(l)
 	}
 
-	if l.ChangeType == "mint" || l.ChangeType == "burn" {
+	if l.ChangeType == tables.ChangeTypeMint || l.ChangeType == tables.ChangeTypeBurn {
 		c.updateUserLiq(l)
 	}
 
-	if l.ChangeType == "cross" {
+	if l.ChangeType == tables.ChangeTypeCross {
 		c.updateKOCross(l)
 	}
 }
@@ -47,14 +47,14 @@ func (c *LiquidityCurve) updateUserLiq(l tables.LiqChange) {
 	askBump := c.materializeBump(l.AskTick)
 
 	liqMagn := determineLiquidityMagn(l)
-	if l.ChangeType == "burn" {
+	if l.ChangeType == tables.ChangeTypeBurn {
 		liqMagn = -liqMagn
 	}
 
 	bidBump.IncrLiquidity(liqMagn, l.Time)
 	askBump.IncrLiquidity(-liqMagn, l.Time)
 
-	if l.PositionType == "knockout" {
+	if l.PositionType == tables.PosTypeKnockout {
 		if l.IsBid > 0 {
 			bidBump.IncrKOBid(liqMagn, l.AskTick)
 		} else {
@@ -145,9 +145,9 @@ func determineLiquidityMagn(r tables.LiqChange) float64 {
 		return 0
 	}
 
-	if r.PositionType == "ambient" {
+	if r.PositionType == tables.PosTypeAmbient {
 		return deriveLiquidityFromAmbientFlow(baseFlow, quoteFlow)
 	} else {
-		return deriveLiquidityFromConcFlow(baseFlow, quoteFlow, r.BidTick, r.AskTick)
+		return DeriveLiquidityFromConcFlow(baseFlow, quoteFlow, r.BidTick, r.AskTick)
 	}
 }

--- a/model/liquidityCurve_test.go
+++ b/model/liquidityCurve_test.go
@@ -13,8 +13,8 @@ func TestAmbientNoop(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "ambient",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeAmbient,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 		IsBid:        1,
@@ -30,8 +30,8 @@ func TestRangeMint(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "concentrated",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeConcentrated,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 	})
@@ -57,8 +57,8 @@ func TestKnockoutBid(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "concentrated",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeConcentrated,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 	})
@@ -70,8 +70,8 @@ func TestKnockoutBid(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "knockout",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeKnockout,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 		IsBid:        1,
@@ -80,8 +80,8 @@ func TestKnockoutBid(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      -250,
-		ChangeType:   "cross",
-		PositionType: "knockout",
+		ChangeType:   tables.ChangeTypeCross,
+		PositionType: tables.PosTypeKnockout,
 		IsBid:        1,
 	})
 
@@ -109,8 +109,8 @@ func TestKnockoutAsk(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "concentrated",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeConcentrated,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 	})
@@ -122,8 +122,8 @@ func TestKnockoutAsk(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      -250,
 		AskTick:      500,
-		ChangeType:   "mint",
-		PositionType: "knockout",
+		ChangeType:   tables.ChangeTypeMint,
+		PositionType: tables.PosTypeKnockout,
 		BaseFlow:     &liqFlow,
 		QuoteFlow:    &liqFlow,
 		IsBid:        0,
@@ -132,8 +132,8 @@ func TestKnockoutAsk(t *testing.T) {
 	curve.UpdateLiqChange(tables.LiqChange{
 		BidTick:      500,
 		AskTick:      500,
-		ChangeType:   "cross",
-		PositionType: "knockout",
+		ChangeType:   tables.ChangeTypeCross,
+		PositionType: tables.PosTypeKnockout,
 		IsBid:        0,
 	})
 

--- a/model/liquidityHistory.go
+++ b/model/liquidityHistory.go
@@ -68,7 +68,7 @@ func (l *LiquidityDeltaHist) appendChange(r tables.LiqChange) {
 	l.initHist()
 	l.assertTimeForward(r.Time)
 
-	if r.ChangeType == "harvest" {
+	if r.ChangeType == tables.ChangeTypeHarvest {
 		l.Hist = append(l.Hist, LiquidityDelta{
 			Time:         r.Time,
 			resetRewards: true,
@@ -77,12 +77,12 @@ func (l *LiquidityDeltaHist) appendChange(r tables.LiqChange) {
 	} else {
 		liqMagn := determineLiquidityMagn(r)
 
-		if r.ChangeType == "mint" {
+		if r.ChangeType == tables.ChangeTypeMint {
 			l.Hist = append(l.Hist, LiquidityDelta{
 				Time:      r.Time,
 				LiqChange: liqMagn})
 
-		} else if r.ChangeType == "burn" {
+		} else if r.ChangeType == tables.ChangeTypeBurn {
 			l.Hist = append(l.Hist, LiquidityDelta{
 				Time:      r.Time,
 				LiqChange: -liqMagn})

--- a/model/liquidityMath.go
+++ b/model/liquidityMath.go
@@ -23,7 +23,7 @@ func derivePriceFromSwapFlow(baseFlow float64, quoteFlow float64, feeRate float6
 	}
 }
 
-func deriveLiquidityFromConcFlow(baseFlow float64, quoteFlow float64,
+func DeriveLiquidityFromConcFlow(baseFlow float64, quoteFlow float64,
 	bidTick int, askTick int) float64 {
 	bidPrice := math.Sqrt(tickToPrice(bidTick))
 	askPrice := math.Sqrt(tickToPrice(askTick))

--- a/model/position.go
+++ b/model/position.go
@@ -8,11 +8,11 @@ import (
 )
 
 type PositionTracker struct {
-	TimeFirstMint    int    `json:"timeFirstMint"`
-	LatestUpdateTime int    `json:"latestUpdateTime"`
-	LastMintTx       string `json:"lastMintTx"`
-	FirstMintTx      string `json:"firstMintTx"`
-	PositionType     string `json:"positionType"`
+	TimeFirstMint    int            `json:"timeFirstMint"`
+	LatestUpdateTime int            `json:"latestUpdateTime"`
+	LastMintTx       string         `json:"lastMintTx"`
+	FirstMintTx      string         `json:"firstMintTx"`
+	PositionType     tables.PosType `json:"positionType"`
 	PositionLiquidity
 	LiqHist LiquidityDeltaHist `json:"-"`
 }
@@ -20,13 +20,13 @@ type PositionTracker struct {
 func (p *PositionTracker) UpdatePosition(l tables.LiqChange) {
 	if p.LatestUpdateTime == 0 || l.Time < p.LatestUpdateTime {
 		p.TimeFirstMint = l.Time
-		if l.ChangeType == "mint" {
+		if l.ChangeType == tables.ChangeTypeMint {
 			p.FirstMintTx = l.TX
 		}
 	}
 	if l.Time > p.LatestUpdateTime {
 		p.LatestUpdateTime = l.Time
-		if l.ChangeType == "mint" {
+		if l.ChangeType == tables.ChangeTypeMint {
 			p.LastMintTx = l.TX
 		}
 	}

--- a/model/txHistory.go
+++ b/model/txHistory.go
@@ -40,9 +40,9 @@ func (h *HistoryWriter) CommitSwap(s tables.Swap) {
 		},
 
 		PoolEventDescriptor: types.PoolEventDescriptor{
-			EntityType:   "swap",
-			ChangeType:   "swap",
-			PositionType: "swap",
+			EntityType:   tables.EntityTypeSwap,
+			ChangeType:   tables.ChangeTypeSwap,
+			PositionType: tables.PosTypeSwap,
 		},
 
 		PoolRangeFields: types.PoolRangeFields{
@@ -63,9 +63,9 @@ func (h *HistoryWriter) CommitLiqChange(s tables.LiqChange) {
 		quoteFlow = *s.QuoteFlow
 	}
 
-	entityType := "liqchange"
-	if s.PositionType == "knockout" {
-		entityType = "limitOrder"
+	entityType := tables.EntityTypeLiqChange
+	if s.PositionType == tables.PosTypeKnockout {
+		entityType = tables.EntityTypeLimit
 	}
 
 	h.commitEventFn(types.PoolTxEvent{

--- a/tables/liqchanges.go
+++ b/tables/liqchanges.go
@@ -21,28 +21,157 @@ func (tbl LiqChangeTable) GetBlock(r LiqChange) int {
 	return r.Block
 }
 
+type PosType int8
+
+const (
+	PosTypeUnknown PosType = iota
+	PosTypeAmbient
+	PosTypeConcentrated
+	PosTypeKnockout
+	PosTypeSwap
+)
+
+var posTypeMap = map[string]PosType{
+	"unknown":      PosTypeUnknown,
+	"ambient":      PosTypeAmbient,
+	"concentrated": PosTypeConcentrated,
+	"knockout":     PosTypeKnockout,
+	"swap":         PosTypeSwap,
+}
+
+var posTypeStringMap = map[PosType]string{
+	PosTypeUnknown:      "unknown",
+	PosTypeAmbient:      "ambient",
+	PosTypeConcentrated: "concentrated",
+	PosTypeKnockout:     "knockout",
+	PosTypeSwap:         "swap",
+}
+
+func (p *PosType) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*p = posTypeMap[s]
+	return nil
+}
+
+func (p PosType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(posTypeStringMap[p])
+}
+
+type ChangeType int8
+
+const (
+	ChangeTypeUnknown ChangeType = iota
+	ChangeTypeMint
+	ChangeTypeBurn
+	ChangeTypeCross
+	ChangeTypeRecover
+	ChangeTypeClaim
+	ChangeTypeHarvest
+	ChangeTypeSwap
+)
+
+var changeTypeMap = map[string]ChangeType{
+	"unknown": ChangeTypeUnknown,
+	"mint":    ChangeTypeMint,
+	"burn":    ChangeTypeBurn,
+	"cross":   ChangeTypeCross,
+	"recover": ChangeTypeRecover,
+	"claim":   ChangeTypeClaim,
+	"harvest": ChangeTypeHarvest,
+	"swap":    ChangeTypeSwap,
+}
+
+var changeTypeStringMap = map[ChangeType]string{
+	ChangeTypeUnknown: "unknown",
+	ChangeTypeMint:    "mint",
+	ChangeTypeBurn:    "burn",
+	ChangeTypeCross:   "cross",
+	ChangeTypeRecover: "recover",
+	ChangeTypeClaim:   "claim",
+	ChangeTypeHarvest: "harvest",
+	ChangeTypeSwap:    "swap",
+}
+
+func (c *ChangeType) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*c = changeTypeMap[s]
+	return nil
+}
+
+func (c ChangeType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(changeTypeStringMap[c])
+}
+
+type EntityType int8
+
+const (
+	EntityTypeUnknown EntityType = iota
+	EntityTypeSwap
+	EntityTypeLimit
+	EntityTypeLiqChange
+)
+
+var entityTypeMap = map[string]EntityType{
+	"unknown":    EntityTypeUnknown,
+	"swap":       EntityTypeSwap,
+	"limitOrder": EntityTypeLimit,
+	"liqchange":  EntityTypeLiqChange,
+}
+
+var entityTypeStringMap = map[EntityType]string{
+	EntityTypeUnknown:   "unknown",
+	EntityTypeSwap:      "swap",
+	EntityTypeLimit:     "limitOrder",
+	EntityTypeLiqChange: "liqchange",
+}
+
+func (e *EntityType) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*e = entityTypeMap[s]
+	return nil
+}
+
+func (e EntityType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityTypeStringMap[e])
+}
+
 type LiqChange struct {
-	ID           string   `json:"id" db:"id"`
-	CallIndex    int      `json:"callIndex" db:"callIndex"`
-	Network      string   `json:"network" db:"network"`
-	TX           string   `json:"tx" db:"tx"`
-	Base         string   `json:"base" db:"base"`
-	Quote        string   `json:"quote" db:"quote"`
-	PoolIdx      int      `json:"poolIdx" db:"poolIdx"`
-	PoolHash     string   `json:"poolHash" db:"poolHash"`
-	User         string   `json:"user" db:"user"`
-	Block        int      `json:"block" db:"block"`
-	Time         int      `json:"time" db:"time"`
-	PositionType string   `json:"positionType" db:"positionType"`
-	ChangeType   string   `json:"changeType" db:"changeType"`
-	BidTick      int      `json:"bidTick" db:"bidTick"`
-	AskTick      int      `json:"askTick" db:"askTick"`
-	IsBid        int      `json:"isBid" db:"isBid"`
-	Liq          *float64 `json:"liq" db:"liq"`
-	BaseFlow     *float64 `json:"baseFlow" db:"baseFlow"`
-	QuoteFlow    *float64 `json:"quoteFlow" db:"quoteFlow"`
-	Source       string   `json:"source" db:"source"`
-	PivotTime    *int     `json:"pivotTime" db:"pivotTime"`
+	ID           string     `json:"id" db:"id"`
+	CallIndex    int        `json:"callIndex" db:"callIndex"`
+	Network      string     `json:"network" db:"network"`
+	TX           string     `json:"tx" db:"tx"`
+	Base         string     `json:"base" db:"base"`
+	Quote        string     `json:"quote" db:"quote"`
+	PoolIdx      int        `json:"poolIdx" db:"poolIdx"`
+	PoolHash     string     `json:"poolHash" db:"poolHash"`
+	User         string     `json:"user" db:"user"`
+	Block        int        `json:"block" db:"block"`
+	Time         int        `json:"time" db:"time"`
+	PositionType PosType    `json:"positionType" db:"positionType"`
+	ChangeType   ChangeType `json:"changeType" db:"changeType"`
+	BidTick      int        `json:"bidTick" db:"bidTick"`
+	AskTick      int        `json:"askTick" db:"askTick"`
+	IsBid        int        `json:"isBid" db:"isBid"`
+	Liq          *float64   `json:"liq" db:"liq"`
+	BaseFlow     *float64   `json:"baseFlow" db:"baseFlow"`
+	QuoteFlow    *float64   `json:"quoteFlow" db:"quoteFlow"`
+	Source       string     `json:"source" db:"source"`
+	PivotTime    *int       `json:"pivotTime" db:"pivotTime"`
 }
 
 type LiqChangeSubGraph struct {
@@ -55,19 +184,18 @@ type LiqChangeSubGraph struct {
 		Quote   string `json:"quote"`
 		PoolIdx string `json:"poolIdx"`
 	} `json:"pool"`
-	Block        string `json:"block"`
-	Time         string `json:"time"`
-	PositionType string `json:"positionType"`
-	ChangeType   string `json:"changeType"`
-	BidTick      int    `json:"bidTick"`
-	AskTick      int    `json:"askTick"`
-	IsBid        bool   `json:"isBid"`
-	Liq          string `json:"liq"`
-	BaseFlow     string `json:"baseFlow"`
-	QuoteFlow    string `json:"quoteFlow"`
-	PivotTime    string `json:"pivotTime"`
+	Block        string     `json:"block"`
+	Time         string     `json:"time"`
+	PositionType PosType    `json:"positionType"`
+	ChangeType   ChangeType `json:"changeType"`
+	BidTick      int        `json:"bidTick"`
+	AskTick      int        `json:"askTick"`
+	IsBid        bool       `json:"isBid"`
+	Liq          string     `json:"liq"`
+	BaseFlow     string     `json:"baseFlow"`
+	QuoteFlow    string     `json:"quoteFlow"`
+	PivotTime    string     `json:"pivotTime"`
 }
-
 type LiqChangeSubGraphData struct {
 	LiqChanges []LiqChangeSubGraph `json:"liquidityChanges"`
 }

--- a/types/exchangeTxs.go
+++ b/types/exchangeTxs.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+
+	"github.com/CrocSwap/graphcache-go/tables"
 )
 
 type PoolTxEvent struct {
@@ -27,9 +29,9 @@ type PoolEventFlow struct {
 }
 
 type PoolEventDescriptor struct {
-	EntityType   string `json:"entityType"`
-	ChangeType   string `json:"changeType"`
-	PositionType string `json:"positionType"`
+	EntityType   tables.EntityType `json:"entityType"`
+	ChangeType   tables.ChangeType `json:"changeType"`
+	PositionType tables.PosType    `json:"positionType"`
 }
 
 type PoolRangeFields struct {
@@ -52,9 +54,9 @@ func (p PoolTxEvent) Hash() [32]byte {
 	buf.WriteString(string(p.Quote))
 	binary.Write(buf, binary.BigEndian, int32(p.PoolIdx))
 
-	buf.WriteString(string(p.EntityType))
-	buf.WriteString(string(p.ChangeType))
-	buf.WriteString(string(p.PositionType))
+	binary.Write(buf, binary.BigEndian, int32(p.EntityType))
+	binary.Write(buf, binary.BigEndian, int32(p.ChangeType))
+	binary.Write(buf, binary.BigEndian, int32(p.PositionType))
 
 	binary.Write(buf, binary.BigEndian, int32(p.BidTick))
 	binary.Write(buf, binary.BigEndian, int32(p.AskTick))

--- a/views/limits.go
+++ b/views/limits.go
@@ -107,13 +107,13 @@ func unrollSubplot(pos types.PositionLocation, subplot *model.KnockoutSubplot) [
 	unrolled := make([]UserLimitOrder, 0)
 
 	if !subplot.Liq.Active.IsEmpty() {
-		claimLoc := pos.ToClaimLoc(0)
+		claimLoc := pos.ToClaimLoc(subplot.Mints[len(subplot.Mints)-1].PivotTime)
 		unrolled = append(unrolled, UserLimitOrder{
 			claimLoc,
 			subplot.Liq.Active,
 			userLimitExtras{
 				LimitId:          formLimitId(claimLoc),
-				LatestUpdateTime: subplot.LatestTime,
+				LatestUpdateTime: subplot.LatestUpdateTime,
 				TimeFirstMint:    subplot.Liq.TimeFirstMint,
 			}})
 	}
@@ -129,12 +129,14 @@ func unrollSubplot(pos types.PositionLocation, subplot *model.KnockoutSubplot) [
 
 			unrolled = append(unrolled, UserLimitOrder{
 				claimLoc,
-				model.PositionLiquidity{},
+				model.PositionLiquidity{
+					RefreshTime: subplot.Liq.Active.RefreshTime,
+				},
 				userLimitExtras{
 					LimitId:          formLimitId(claimLoc),
 					CrossTime:        crossTime,
 					ClaimableLiq:     claim.ConcLiq,
-					LatestUpdateTime: subplot.LatestTime,
+					LatestUpdateTime: subplot.LatestUpdateTime,
 					TimeFirstMint:    subplot.Liq.TimeFirstMint,
 				}})
 		}

--- a/views/positions.go
+++ b/views/positions.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/CrocSwap/graphcache-go/model"
+	"github.com/CrocSwap/graphcache-go/tables"
 	"github.com/CrocSwap/graphcache-go/types"
 )
 
@@ -18,7 +19,7 @@ type UserPosition struct {
 
 type HistoricUserPosition struct {
 	types.PositionLocation
-	PositionType  string                   `json:"positionType"`
+	PositionType  tables.PosType           `json:"positionType"`
 	TimeFirstMint int                      `json:"timeFirstMint"`
 	FirstMintTx   string                   `json:"firstMintTx"`
 	PositionId    string                   `json:"positionId"`
@@ -182,11 +183,11 @@ func (v *Views) QueryHistoricPositions(chainId types.ChainId, base types.EthAddr
 			if position.TimeFirstMint > time {
 				continue
 			}
-			if position.PositionType == "concentrated" {
+			if position.PositionType == tables.PosTypeConcentrated {
 				liqSumBig, _ := big.NewFloat(liqSum).Int(nil)
 				position.Liq = liqSumBig
 				position.BaseTokens, position.QuoteTokens = model.DeriveTokensFromConcLiquidity(liqSum, position.BidTick, position.AskTick, poolPrice)
-			} else if position.PositionType == "ambient" {
+			} else if position.PositionType == tables.PosTypeAmbient {
 				liqSumBig, _ := big.NewFloat(liqSum).Int(nil)
 				position.Liq = liqSumBig
 				position.BaseTokens, position.QuoteTokens = model.DeriveTokensFromAmbLiquidity(liqSum, poolPrice)


### PR DESCRIPTION
Issues:
1. Liquidity refresher consumed two thirds of the RAM used by graphcache - tens of gigabytes for Scroll.
2. When running periodic rewards refreshes every 30 minutes all other liquidity refreshes would stop, so new positions and limit orders would be stuck in queue (for about 20 minutes for Scroll).
3. Because of point 2, limit orders would not appear in the list if a periodic refresh was going on at the same time.
4. A limit order would sometimes show up as two orders after becoming claimable, confusing users. Even after claiming an unclaimable ghost would remain until graphcache was restarted.

Fixes:
1. Liquidity refresher was rewritten to be very lean (relatively - it doesn't needlessly spawn hundreds of thousands goroutines with large buffered channels anymore).
2. Added urgent refresh queue which takes priority over the slow queue where periodic refreshes go.
3. Limit order tracking was rewritten to use derived liquidity units and tracked pivot times to reconstruct the correct limit order state even without RPC calls, so it will be correct before the startup RPC sync finishes (but since the RPC calls didn't go anywhere, if there are issues with the derived state it will be overwritten by the usual RPC call).
4. Fixed by point 3 (mostly - it used to happen quite often but only happened once when running with these changes, will need to investigate further).